### PR TITLE
fix(ci): enable pub.dev OIDC by adding dart-lang/setup-dart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write   # gh release create
     steps:
       - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.7'


### PR DESCRIPTION
## Problem

The first real tag push (`v0.2.1`) through `.github/workflows/publish.yml` hung for ~14 minutes in the Publish step before being canceled. Workflow log:

```
06:22:39  Pub needs your authorization to upload packages on your behalf.
06:22:39  In a web browser, go to https://accounts.google.com/o/oauth2/auth?...
06:22:39  Waiting for your authorization...
06:36:21  ##[error]The operation was canceled.
```

Root cause: `dart pub publish --force` fell back to interactive OAuth because the OIDC environment wasn't initialized. `--force` skips the `y/N` prompt but does **not** skip the OAuth browser flow when OIDC credentials aren't present. CI has no TTY, so it hung.

## Why it didn't just work

`subosito/flutter-action@v2` installs Flutter (including bundled Dart) but does **not** configure pub.dev's automated publishing OIDC hooks. That initialization is done by `dart-lang/setup-dart@v1`, which is why rfw_gen's reference workflow uses both actions in sequence:

```yaml
- uses: dart-lang/setup-dart@v1     # ← initializes OIDC auth
- uses: subosito/flutter-action@v2  # ← installs Flutter on top
```

See Dart's automated publishing guide: https://dart.dev/tools/pub/automated-publishing

## Fix

One-line addition to `.github/workflows/publish.yml`:

```diff
     steps:
       - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
       - uses: subosito/flutter-action@v2
```

No other changes needed. Gate chain, guard, publish, release creation stay identical.

## Post-merge validation

After merge to main, re-push `v0.2.1` tag (deleted locally + remotely before this PR). The workflow should proceed through Publish and create the GitHub Release, actually delivering pixel_ui 0.2.1 to pub.dev.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"` — ok)
- [ ] Post-merge: re-tag `v0.2.1`, confirm Publish step completes without hanging, verify pub.dev 0.2.1 appears and GitHub Release is created