### PR TITLE
ci: analyze and test tuner sub-package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,24 @@ jobs:
           channel: 'stable'
       - name: Pub get (root package)
         run: flutter pub get
+      - name: Pub get (example)
+        run: flutter pub get
+        working-directory: example
+      - name: Pub get (tuner)
+        run: flutter pub get
+        working-directory: tuner
       - name: Analyze (package)
         run: flutter analyze
       - name: Test (package)
         run: flutter test --exclude-tags screenshot
       - name: Publish dry-run
         run: dart pub publish --dry-run
-      - name: Pub get (example)
-        run: flutter pub get
-        working-directory: example
       - name: Analyze (example)
         run: flutter analyze
         working-directory: example
+      - name: Analyze (tuner)
+        run: flutter analyze
+        working-directory: tuner
+      - name: Test (tuner)
+        run: flutter test
+        working-directory: tuner


### PR DESCRIPTION
## Summary
- Adds `flutter pub get` / `analyze` / `test` steps for the `tuner/` sub-package in the Test workflow.
- Reorders steps so pub get runs for root, example, and tuner up front — this fixes a pre-existing regression where root \`flutter analyze\` failed on fresh checkouts because \`tuner/test/*.dart\` referenced \`package:pixel_ui_tuner/...\` with no \`.dart_tool/\` present.
- Root workflow now covers all three packages (pixel_ui, example, pixel_ui_tuner).

## Why
The Test workflow has been red on \`main\` since PR #5 (tuner) merged. Locally it passed because \`tuner/.dart_tool/\` existed from prior \`pub get\`. CI fresh checkouts had no such cache.

## Test plan
- [x] \`cd tuner && fvm flutter pub get && fvm flutter analyze && fvm flutter test\` → all pass locally
- [x] \`fvm flutter analyze\` (root) → no issues
- [ ] CI Test workflow green on this PR