### PR TITLE
docs: v0.3.0 nes_ui absorb design spec

### DIFF
--- a/docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md
+++ b/docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md
@@ -1,0 +1,125 @@
+# v0.3.0 — nes_ui 흡수 설계 스펙
+
+**작성일**: 2026-04-23
+**대상 버전**: 0.3.0
+**상태**: 설계 확정, 구현은 GitHub 이슈 단위로 진행
+
+---
+
+## 배경
+
+pub.dev 공개(0.1.0) 후 "다음 로드맵"을 고민하던 중 npm의 `@react-pixel-ui/core`를 발견했다. 처음엔 "더 성숙한 패키지"로 보고 아이디어를 차용할 생각이었으나, 경쟁군 조사 결과 전제 자체가 잘못됐음을 확인했다.
+
+### 조사 결과 (요약)
+
+| 패키지 | ★ / 주간 dl | 평가 |
+|---|---|---|
+| `@react-pixel-ui/react` | 1★ / 10건 | **신생 1인 실험** — 컴포넌트 0개, 토큰 없음, 2026-04 첫 publish |
+| NES.css | 21.7k★ / 1,285/wk | 카테고리 No.1 CSS 프레임워크 (6년 유지) |
+| 98.css | 11k★ / 9,405/wk | 2025년에도 활발, CSS custom props |
+| @react95/core | 3.8k★ | Figma kit + 토큰 시스템 |
+| **nes_ui (Flutter)** | **119♥ / 893/월** | `ThemeExtension` 기반, Widgetbook 카탈로그, Flame 커뮤니티. **pixel_ui의 진짜 벤치마크** |
+
+**결론**: react-pixel-ui는 "성숙"이 아니라 "1인 실험". Flutter에서 실제 벤치마크는 `nes_ui`. 재설계 방향은 nes_ui 기반으로 변경.
+
+### react-pixel-ui를 거부한 이유
+
+- "자동 픽셀화"의 핵심 기법(`getComputedStyle` 관찰 + `clip-path: polygon()` 교체)은 **웹 DOM 전용**. Flutter에 RenderObject 프록시로 포팅 시 유지보수 부채 과다.
+- 다른 레트로 UI 라이브러리 중 **어느 곳도 runtime style observation을 채택하지 않음** → 업계 표준 아님.
+- 어댑션 근거(662 dl)도 `/core` 패키지 기준이며, React 바인딩(`/react`)은 10 dl. "수요 검증된 API"로 간주 불가.
+
+---
+
+## 흡수 전략: 아키텍처만, 위젯은 거부
+
+nes_ui의 진짜 자산은 **위젯 20여 개가 아니라 `ThemeExtension` + `painter 빌더 주입` 아키텍처**. 위젯은:
+- 절반은 pixel_ui와 중복(NesContainer=PixelBox, NesButton=PixelButton)
+- 일부는 pixel_ui의 `PixelCorners(List<int>)`보다 **표현력이 떨어짐**(nes_ui는 `cornerSteps: int` uniform만 지원)
+- 나머지는 NES/레트로 OS 특화로 pixel_ui의 "범용 픽셀 아트 디자인 시스템" 지향과 불일치
+
+---
+
+## ✅ 0.3.0 흡수 확정 (4개)
+
+| # | 항목 | 핵심 | Issue |
+|---|---|---|---|
+| 1 | `PixelTheme` ThemeExtension 시스템 | `MaterialApp(theme: pixelUiTheme())` 한 번으로 전체 스타일 상속. 기존 API 완전 하위호환 | (TBD) |
+| 2 | Painter builder 주입 | theme에 `PixelShapePainterBuilder` 슬롯. 사용자 커스텀 painter 교체 가능. nes_ui의 최강 확장 포인트 | (TBD) |
+| 3 | `PixelBox.label` | 상단 보더에 겹치는 라벨 (`[ TITLE ]━━━━━`). painter가 영역 carve-out | (TBD) |
+| 4 | `PixelShadow.style = stipple` | 체커-점묘 그림자 스타일. enum 추가 + painter 분기 10줄 | (TBD) |
+
+### 처리 순서
+**#1 → #2 → #4 → #3**
+- #1: 토대(먼저)
+- #2: #1에 슬롯만 추가 (작음)
+- #4: 독립적, painter 10줄 (빠른 승리감)
+- #3: painter carve-out + tuner 작업 동반 (가장 큼, 마지막)
+
+### 0.3.0 원칙
+- **하위호환 유지**: 모든 기존 `PixelBox(style: ...)` / `PixelButton(normalStyle: ...)` 호출 변경 없이 동작
+- **breaking change 없음**: 0.3.0 minor bump로 안전
+- **tuner 쇼케이스**: #3, #4는 `feat/tuner` 브랜치에 토글 추가해 시각화
+
+---
+
+## ⏸️ 보류 (실사용 피드백 대기)
+
+GitHub 이슈로는 만들되 `needs-feedback` label + milestone 없음. 실수요 확인 시 label 제거 + milestone 배정.
+
+| # | 항목 | 보류 사유 |
+|---|---|---|
+| 5 | `PixelSemantic` enum + `PixelColorScheme` (primary/success/warning/error) | 지금 색 5종 고정하면 나중에 변경 비용. 실수요 뜨면 반영 |
+| 6 | `PixelSnackbar` | `PixelBox` + `ScaffoldMessenger` 조합만으로 구현 가능 (primitive 추가 없음). 필요 순간 즉시 가능 |
+| 7 | 위젯 umbrella: `PixelCheckBox`, `PixelInput`, `PixelDialog`, `PixelTooltip`, `PixelProgressBar` | 각각 별도 이슈로 fork. **모두 `PixelBox`+`PixelShapePainter` 조합으로만 구현. 새 primitive 금지** |
+| 8 | Alchemist golden + per-platform baseline | 현재 `--exclude-tags screenshot` 회피로 충분. MEMORY에 "dual-baseline 가치 있을 때 재방문"으로 기록됨 |
+
+---
+
+## ❌ 영구 거부
+
+| 항목 | 사유 |
+|---|---|
+| `cornerSteps: int` (nes_ui 방식) | pixel_ui의 `PixelCorners(List<int>)`가 상위 호환. 베끼면 표현력 퇴화 |
+| mini_sprite 기반 132개 아이콘 (`NesIcons`) | 외부 의존성(`flutter_mini_sprite`) + YAGNI. 필요하면 별도 `pixel_ui_icons` 패키지로 분리 |
+| MouseCursor 13종 토큰 | pixel_ui는 모바일 우선. 데스크탑 커서 13종은 범위 밖 |
+| `NesWindow` (드래그 가능 창) | 데스크탑 OS UX. 모바일 부적합. 필요 시 `PixelBox` + GestureDetector로 사용자 조합 |
+| `NesDpad` (방향 버튼) | 게임 입력 컨트롤러. pixel_ui는 디자인 시스템이지 게임 UI 프레임워크 아님 (Flame + nes_ui 영역) |
+| `NesRunningText` (CRT/타자기 효과) | 애니메이션 특화, 정적 shape 모델과 결이 다름. 다른 레트로 UI 라이브러리도 없음 |
+| `NesArcadeLabel` | `PixelText.mulmaru(fontSize: 64)` + `PixelBox`로 사용자 조합 가능. API 비대화 방지 |
+| `NesFileExplorer` | 파일 브라우저 UI. pixel_ui 범위에서 가장 멀리 있음 |
+| runtime CSS observation (react-pixel-ui 기법) | Flutter에 부적합 + 업계 표준 아님. 다른 라이브러리 아무도 안 함 |
+
+**거부 항목은 GitHub 이슈로 만들지 않음.** 누군가 나중에 "PixelCursor 넣자"고 PR/이슈 열면 이 스펙 링크 붙이고 close.
+
+---
+
+## 성숙 라이브러리 공통 DNA (참고)
+
+향후 로드맵 판단 시 참조용.
+
+**공통으로 있는 것 (→ 점진적으로 채울 갭)**:
+1. 테마/토큰 시스템 — ✅ 0.3.0 #1에서 도입
+2. 컴포넌트 인벤토리 폭 — ⏸ 보류 #7 umbrella에서 순차적
+3. 폰트 스토리 + 공개 카탈로그 — ✅ Mulmaru 번들 완료, `feat/tuner`가 카탈로그 역할
+
+**공통으로 없는 것 (→ 압박감 불필요)**:
+- 풀 WCAG 접근성 (레트로 미학 사용자 요구 없음)
+- 다크 모드 (레트로는 canonical 단일 look)
+- 폼 validation UX
+- runtime style observation
+
+---
+
+## 버전 계획
+
+- **0.3.0**: 위 4개 흡수 + CHANGELOG 작성 + `v0.3.0` 태그 push → OIDC 자동 배포
+- **0.3.x 패치**: 보류 항목 중 실수요 발생 시 minor 추가 배포
+- **1.0.0**: 0.3.x 피드백 소화 후 API 안정 선언
+
+---
+
+## 관련 문서
+
+- 로드맵: `docs/ROADMAP.md`
+- 튜너 설계: `docs/specs/2026-04-22-tuner-design.md`
+- 기존 스펙: `docs/specs/2026-04-22-v0.2.0-platform-expansion-design.md`, `docs/specs/2026-04-23-test-ci-and-painter-goldens-design.md`

--- a/docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md
+++ b/docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md
@@ -43,17 +43,17 @@ nes_ui의 진짜 자산은 **위젯 20여 개가 아니라 `ThemeExtension` + `p
 
 | # | 항목 | 핵심 | Issue |
 |---|---|---|---|
-| 1 | `PixelTheme` ThemeExtension 시스템 | `MaterialApp(theme: pixelUiTheme())` 한 번으로 전체 스타일 상속. 기존 API 완전 하위호환 | (TBD) |
-| 2 | Painter builder 주입 | theme에 `PixelShapePainterBuilder` 슬롯. 사용자 커스텀 painter 교체 가능. nes_ui의 최강 확장 포인트 | (TBD) |
-| 3 | `PixelBox.label` | 상단 보더에 겹치는 라벨 (`[ TITLE ]━━━━━`). painter가 영역 carve-out | (TBD) |
-| 4 | `PixelShadow.style = stipple` | 체커-점묘 그림자 스타일. enum 추가 + painter 분기 10줄 | (TBD) |
+| 1 | `PixelTheme` ThemeExtension 시스템 | `MaterialApp(theme: pixelUiTheme())` 한 번으로 전체 스타일 상속. 기존 API 완전 하위호환 | [#8](https://github.com/BottlePumpkin/pixel_ui/issues/8) |
+| 2 | Painter builder 주입 | theme에 `PixelShapePainterBuilder` 슬롯. 사용자 커스텀 painter 교체 가능. nes_ui의 최강 확장 포인트 | [#9](https://github.com/BottlePumpkin/pixel_ui/issues/9) |
+| 3 | `PixelBox.label` | 상단 보더에 겹치는 라벨 (`[ TITLE ]━━━━━`). painter가 영역 carve-out | [#10](https://github.com/BottlePumpkin/pixel_ui/issues/10) |
+| 4 | `PixelShadow.style = stipple` | 체커-점묘 그림자 스타일. enum 추가 + painter 분기 10줄 | [#11](https://github.com/BottlePumpkin/pixel_ui/issues/11) |
 
 ### 처리 순서
-**#1 → #2 → #4 → #3**
-- #1: 토대(먼저)
-- #2: #1에 슬롯만 추가 (작음)
-- #4: 독립적, painter 10줄 (빠른 승리감)
-- #3: painter carve-out + tuner 작업 동반 (가장 큼, 마지막)
+**#8 → #9 → #11 → #10**
+- #8: 토대(먼저)
+- #9: #8에 슬롯만 추가 (작음)
+- #11: 독립적, painter 10줄 (빠른 승리감)
+- #10: painter carve-out + tuner 작업 동반 (가장 큼, 마지막)
 
 ### 0.3.0 원칙
 - **하위호환 유지**: 모든 기존 `PixelBox(style: ...)` / `PixelButton(normalStyle: ...)` 호출 변경 없이 동작
@@ -66,12 +66,12 @@ nes_ui의 진짜 자산은 **위젯 20여 개가 아니라 `ThemeExtension` + `p
 
 GitHub 이슈로는 만들되 `needs-feedback` label + milestone 없음. 실수요 확인 시 label 제거 + milestone 배정.
 
-| # | 항목 | 보류 사유 |
+| 항목 | 보류 사유 | Issue |
 |---|---|---|
-| 5 | `PixelSemantic` enum + `PixelColorScheme` (primary/success/warning/error) | 지금 색 5종 고정하면 나중에 변경 비용. 실수요 뜨면 반영 |
-| 6 | `PixelSnackbar` | `PixelBox` + `ScaffoldMessenger` 조합만으로 구현 가능 (primitive 추가 없음). 필요 순간 즉시 가능 |
-| 7 | 위젯 umbrella: `PixelCheckBox`, `PixelInput`, `PixelDialog`, `PixelTooltip`, `PixelProgressBar` | 각각 별도 이슈로 fork. **모두 `PixelBox`+`PixelShapePainter` 조합으로만 구현. 새 primitive 금지** |
-| 8 | Alchemist golden + per-platform baseline | 현재 `--exclude-tags screenshot` 회피로 충분. MEMORY에 "dual-baseline 가치 있을 때 재방문"으로 기록됨 |
+| `PixelSemantic` enum + `PixelColorScheme` (primary/success/warning/error) | 지금 색 5종 고정하면 나중에 변경 비용. 실수요 뜨면 반영 | [#12](https://github.com/BottlePumpkin/pixel_ui/issues/12) |
+| `PixelSnackbar` | `PixelBox` + `ScaffoldMessenger` 조합만으로 구현 가능 (primitive 추가 없음). 필요 순간 즉시 가능 | [#13](https://github.com/BottlePumpkin/pixel_ui/issues/13) |
+| 위젯 umbrella: `PixelCheckBox`, `PixelInput`, `PixelDialog`, `PixelTooltip`, `PixelProgressBar` | 각각 별도 이슈로 fork. **모두 `PixelBox`+`PixelShapePainter` 조합으로만 구현. 새 primitive 금지** | [#14](https://github.com/BottlePumpkin/pixel_ui/issues/14) |
+| Alchemist golden + per-platform baseline | 현재 `--exclude-tags screenshot` 회피로 충분. MEMORY에 "dual-baseline 가치 있을 때 재방문"으로 기록됨 | [#15](https://github.com/BottlePumpkin/pixel_ui/issues/15) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Capture brainstorming outcome on v0.3.0 direction after surveying retro UI libraries (NES.css, 98.css, @react95/core, nes_ui, @react-pixel-ui/core).
- Decision: absorb `nes_ui`'s **ThemeExtension + painter-builder-injection architecture**, not its widgets. The real Flutter benchmark is `nes_ui`, not the novel-but-tiny `@react-pixel-ui/core` (10 weekly npm dl, 1 star).
- Scope split: 4 active issues on v0.3.0 milestone, 4 deferred with `needs-feedback`, rest permanently rejected with rationale in spec.

## Issues created
Active (v0.3.0):
- #8 PixelTheme ThemeExtension system
- #9 Painter builder injection
- #10 PixelBox.label
- #11 Stipple-style shadow

Deferred (`needs-feedback`):
- #12 PixelSemantic enum + PixelColorScheme
- #13 PixelSnackbar
- #14 Additional widgets umbrella
- #15 Alchemist golden + per-platform baseline

Processing order: **#8 → #9 → #11 → #10**

## Test plan
- [ ] Spec file renders correctly on GitHub
- [ ] All 8 linked issues open with expected labels/milestone
- [ ] No existing tests affected (docs-only change)