### PR TITLE
docs: fix stale README Install version + exclude dogfood dirs from analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pixel-art design system for Flutter — parametric shapes, interactive buttons, 
 
 ```yaml
 dependencies:
-  pixel_ui: ^0.1.0
+  pixel_ui: ^0.2.0
 ```
 
 ## Quick Start

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  exclude:
+    - dogfood_cycle_*/**
   language:
     strict-casts: true
     strict-inference: true


### PR DESCRIPTION
Closes #19

## 변경사항

- README Install 섹션 `pixel_ui: ^0.1.0` → `^0.2.0` (현재 최신 `0.2.1` 포함하는 constraint)
- `analysis_options.yaml`에 `exclude: - dogfood_cycle_*/**` 추가 — throwaway 앱의 기본 template 코드가 메인 프로젝트 analyze를 깨뜨리는 부수 문제 해결

## Why

cycle #1 (C1 게임 UI 신규 사용자) 페르소나가 README Install 예제 그대로 `^0.1.0`을 pubspec에 넣고 Typography 섹션의 \`PixelText.mulmaruMono\`를 쓰려다 Dart 컴파일 에러를 만남. \`^0.1.0\`은 \`0.1.0\`/\`0.1.1\`만 허용, \`0.2.1\`(MulmaruMono 추가 버전) 제외.

## 검증

- [x] \`fvm flutter analyze\` — clean
- [x] \`fvm flutter test --exclude-tags screenshot\` — 79/79 pass
- [x] (widget-gap 아님, 8-항목 체크리스트 적용 안 됨)

## 보너스 발견

\`analysis_options.yaml\` 누락은 cycle #1 verify 단계에서 발견됨 — dogfood throwaway가 \`.gitignore\`만 있고 analyzer exclude가 없어서 \`flutter analyze\`가 오류 토해냄. 다음 dogfood 사이클부턴 재발하지 않음.

## 다음 케어

매 릴리스 체크리스트에 "README Install 버전 동반 bump" 항목을 CLAUDE.md 배포 리듬 섹션에 추가하는 것 권장 (별도 PR).