### PR TITLE
docs: document logical→screen sizing model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ PixelButton(
 );
 ```
 
+### Sizing model
+
+`logicalWidth` and `logicalHeight` are **integer pixel-art grid cells**, not
+screen pixels. When you don't pass `width:` / `height:`, the widget renders at
+**logical size × 4** screen pixels (so `logicalWidth: 60, logicalHeight: 18`
+→ 240×72 dp). Override either dimension to stretch the same logical grid to a
+custom screen size — the painter still draws at the logical resolution so
+pixels stay crisp. Aspect ratio is preserved if only one of `width`/`height`
+is given.
+
+The logical values also drive corner stair patterns, shadow offsets, and
+texture cell sizes, so think of them as the "pixel art canvas" the design
+is authored on.
+
 ## Usage
 
 ### Corners


### PR DESCRIPTION
Closes #20

## 변경사항

README Quick Start 바로 아래 `### Sizing model` 서브섹션 추가:
- `logicalWidth`/`logicalHeight`는 픽셀 아트 grid cell (screen pixel 아님)
- 기본 렌더 크기 = logical × 4 dp (ex: 60×18 → 240×72 dp)
- `width`/`height` 오버라이드 시 logical grid는 유지, 화면 크기만 변경 (aspect ratio 보존)
- logical 값은 corners stair · shadow offset · texture cell size에도 동일하게 적용

## Why

cycle #1 C1 페르소나가 README Quick Start의 `logicalWidth: 60, logicalHeight: 18`만 보고 배율 단서 없이 시행착오로 버튼 크기를 찾아야 했음. 출처는 `PixelBox` dartdoc (\`defaults to logical size × 4\`)에 있지만 공개 API doc이 아니라 README에만 있어야 하는 내용.

## 검증

- [x] \`fvm flutter analyze\` — clean
- [x] (docs-only, 추가 테스트 없음)
- [x] (widget-gap 아님, 8-항목 체크리스트 적용 안 됨)