### PR TITLE
feat: PixelButton.disabledStyle for explicit disabled visual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `PixelButton.disabledStyle` optional parameter — explicit `PixelShapeStyle` shown when `onPressed` is `null`. Unspecified keeps the existing behavior (`normalStyle` rendered at 50% opacity).
+
 ## 0.2.1 — 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,12 +103,18 @@ PixelButton(
   logicalHeight: 18,
   normalStyle: /* PixelShapeStyle */,
   pressedStyle: /* optional, falls back to normalStyle */,
+  disabledStyle: /* optional, falls back to normalStyle at 50% opacity */,
   pressChildOffset: const Offset(0, 1),
   onPressed: () {},
   semanticsLabel: 'Start',
   child: /* your child widget */,
 );
 ```
+
+When `onPressed` is `null` the button is non-interactive. If you pass a
+`disabledStyle` it renders at full opacity with that style; otherwise the
+button falls back to `normalStyle` rendered at 50% opacity — a generic dim
+that avoids a distracting visual when you don't need one.
 
 ### Texture
 

--- a/lib/src/pixel_button.dart
+++ b/lib/src/pixel_button.dart
@@ -3,11 +3,13 @@ import 'package:flutter/widgets.dart';
 import 'package:pixel_ui/src/pixel_box.dart';
 import 'package:pixel_ui/src/pixel_style.dart';
 
-/// Interactive pixel button with optional press-state style.
+/// Interactive pixel button with optional press-state and disabled-state styles.
 ///
-/// Visuals come from [normalStyle] in the default state and [pressedStyle] when
-/// pressed (falling back to [normalStyle] if not provided). The child can be
-/// shifted down by [pressChildOffset] while pressed, simulating a button press.
+/// Visuals come from [normalStyle] in the default state, [pressedStyle] when
+/// pressed (falling back to [normalStyle] if not provided), and [disabledStyle]
+/// when [onPressed] is null (falling back to [normalStyle] rendered at 50%
+/// opacity if not provided). The child can be shifted down by
+/// [pressChildOffset] while pressed, simulating a button press.
 class PixelButton extends StatefulWidget {
   final int logicalWidth;
   final int logicalHeight;
@@ -16,6 +18,10 @@ class PixelButton extends StatefulWidget {
 
   /// Style to show while pressed. `null` keeps [normalStyle].
   final PixelShapeStyle? pressedStyle;
+
+  /// Style to show when [onPressed] is `null`. `null` keeps [normalStyle]
+  /// rendered at 50% opacity (the default dimmed look).
+  final PixelShapeStyle? disabledStyle;
 
   final double? width;
   final double? height;
@@ -39,6 +45,7 @@ class PixelButton extends StatefulWidget {
     required this.logicalHeight,
     required this.normalStyle,
     this.pressedStyle,
+    this.disabledStyle,
     this.width,
     this.height,
     this.padding,
@@ -60,8 +67,16 @@ class _PixelButtonState extends State<PixelButton> {
   bool get _enabled => widget.onPressed != null;
 
   PixelShapeStyle get _currentStyle {
+    if (!_enabled && widget.disabledStyle != null) return widget.disabledStyle!;
     if (_pressed && widget.pressedStyle != null) return widget.pressedStyle!;
     return widget.normalStyle;
+  }
+
+  double get _opacity {
+    // Only dim when falling back to normalStyle in the disabled state;
+    // a custom disabledStyle already carries the author's intent.
+    if (!_enabled && widget.disabledStyle == null) return 0.5;
+    return 1.0;
   }
 
   void _setPressed(bool v) {
@@ -84,7 +99,7 @@ class _PixelButtonState extends State<PixelButton> {
         onTapCancel: () => _setPressed(false),
         onTap: _enabled ? () => widget.onPressed!() : null,
         child: Opacity(
-          opacity: _enabled ? 1.0 : 0.5,
+          opacity: _opacity,
           child: PixelBox(
             logicalWidth: widget.logicalWidth,
             logicalHeight: widget.logicalHeight,

--- a/test/pixel_button_test.dart
+++ b/test/pixel_button_test.dart
@@ -78,6 +78,80 @@ void main() {
     handle.dispose();
   });
 
+  testWidgets('PixelButton uses disabledStyle when provided and onPressed is null',
+      (tester) async {
+    const disabledStyle = PixelShapeStyle(
+      corners: PixelCorners.md,
+      fillColor: Color(0xFF888888),
+    );
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: PixelButton(
+            logicalWidth: 10,
+            logicalHeight: 5,
+            normalStyle: normalStyle,
+            disabledStyle: disabledStyle,
+            onPressed: null,
+            child: Text('x'),
+          ),
+        ),
+      ),
+    );
+    final customPaint = tester.widget<CustomPaint>(find.byType(CustomPaint).first);
+    final painter = customPaint.painter! as PixelShapePainter;
+    expect(painter.style, disabledStyle);
+  });
+
+  testWidgets(
+      'PixelButton falls back to normalStyle when disabledStyle is null and onPressed is null',
+      (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: PixelButton(
+            logicalWidth: 10,
+            logicalHeight: 5,
+            normalStyle: normalStyle,
+            onPressed: null,
+            child: Text('x'),
+          ),
+        ),
+      ),
+    );
+    final customPaint = tester.widget<CustomPaint>(find.byType(CustomPaint).first);
+    final painter = customPaint.painter! as PixelShapePainter;
+    expect(painter.style, normalStyle);
+  });
+
+  testWidgets('PixelButton ignores disabledStyle when onPressed is provided',
+      (tester) async {
+    const disabledStyle = PixelShapeStyle(
+      corners: PixelCorners.md,
+      fillColor: Color(0xFF888888),
+    );
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: PixelButton(
+            logicalWidth: 10,
+            logicalHeight: 5,
+            normalStyle: normalStyle,
+            disabledStyle: disabledStyle,
+            onPressed: () {},
+            child: const Text('x'),
+          ),
+        ),
+      ),
+    );
+    final customPaint = tester.widget<CustomPaint>(find.byType(CustomPaint).first);
+    final painter = customPaint.painter! as PixelShapePainter;
+    expect(painter.style, normalStyle);
+  });
+
   testWidgets('PixelButton switches to pressed style on tap down', (tester) async {
     await tester.pumpWidget(
       Directionality(


### PR DESCRIPTION
Closes #18

## 변경사항

`PixelButton`에 `disabledStyle: PixelShapeStyle?` optional 파라미터 추가 (non-breaking).

- `onPressed: null` + `disabledStyle` 지정됨 → `disabledStyle`을 full opacity로 렌더 (작성자 의도 반영)
- `onPressed: null` + `disabledStyle: null` → 기존 동작 유지 (`normalStyle` + 50% opacity 디밍)
- `onPressed: () {}` → `disabledStyle` 무시

## Why

cycle #1 C1 페르소나가 계산기의 `=` 버튼을 비활성 상태로 표시하려 했으나 `onPressed: null`만으로는 READING 레벨에서 시각 단서가 불충분하다고 느낌. README에 50% opacity 기본 동작도 문서화돼 있지 않아 discoverability가 약함. 게임 UI 맥락(스킬 쿨다운, 조건부 액션 버튼)에선 상시 수요.

## 검증

- [x] `fvm flutter analyze` — clean
- [x] `fvm flutter test --exclude-tags screenshot` — 82/82 pass (기존 79 + 신규 3)
- [x] 새 테스트 3개 (각 분기 커버):
  - `disabledStyle` + `onPressed: null` → painter receives `disabledStyle`
  - `disabledStyle: null` + `onPressed: null` → painter receives `normalStyle` (기존 동작 보존)
  - `disabledStyle` + `onPressed: () {}` → `disabledStyle` ignored
- [x] README PixelButton 섹션 갱신 (`disabledStyle` 라인 + 기본 50% opacity 동작 문서화)
- [x] CHANGELOG `## Unreleased` 섹션 신설 + 엔트리 추가

## 비고

이 작업은 widget-gap이 아니라 기존 위젯의 API 확장이라 8-항목 widget-gap 체크리스트는 적용 안 됨. 다만 실질적으로 공개 API 노출·단위 테스트·README·CHANGELOG는 전부 만족.