### PR TITLE
chore(dogfood): create bug/feature/docs labels in prereqs

### DIFF
--- a/.claude/skills/dogfood/SKILL.md
+++ b/.claude/skills/dogfood/SKILL.md
@@ -22,13 +22,16 @@ user_invocable: true
 3. **GitHub 라벨 생성** — 아래 스크립트 idempotent 실행:
 
 ```bash
-gh label create dogfood    --color 0E8A16 --description "Dogfood cycle issue"        2>/dev/null || true
-gh label create dx         --color D93F0B --description "Developer experience issue" 2>/dev/null || true
-gh label create widget-gap --color 5319E7 --description "Missing widget request"     2>/dev/null || true
-gh label create tuner      --color FBCA04 --description "Tuner-related"              2>/dev/null || true
-gh label create stale      --color CCCCCC --description "Outdated content"           2>/dev/null || true
-gh label create missing    --color EEEEEE --description "Missing coverage"           2>/dev/null || true
-gh label create upstream   --color BFD4F2 --description "Upstream Flutter limit"     2>/dev/null || true
+gh label create dogfood    --color 0E8A16 --description "Dogfood cycle issue"                 2>/dev/null || true
+gh label create bug        --color D73A4A --description "Something isn't working"              2>/dev/null || true
+gh label create feature    --color A2EEEF --description "New feature or request"               2>/dev/null || true
+gh label create docs       --color 0075CA --description "Improvements or additions to documentation" 2>/dev/null || true
+gh label create dx         --color D93F0B --description "Developer experience issue"           2>/dev/null || true
+gh label create widget-gap --color 5319E7 --description "Missing widget request"               2>/dev/null || true
+gh label create tuner      --color FBCA04 --description "Tuner-related"                        2>/dev/null || true
+gh label create stale      --color CCCCCC --description "Outdated content"                     2>/dev/null || true
+gh label create missing    --color EEEEEE --description "Missing coverage"                     2>/dev/null || true
+gh label create upstream   --color BFD4F2 --description "Upstream Flutter limit"               2>/dev/null || true
 ```
 
 4. **.gitignore 체크** — `dogfood_cycle_*/` 패턴 없으면 추가 후 커밋.

--- a/docs/superpowers/specs/2026-04-23-dogfood-skill-design.md
+++ b/docs/superpowers/specs/2026-04-23-dogfood-skill-design.md
@@ -178,16 +178,19 @@ dependencies:
 ### 8.3 라벨 자동 생성 (Prereqs)
 
 ```bash
-gh label create dogfood    --color 0E8A16 --description "Dogfood cycle issue"        2>/dev/null || true
-gh label create dx         --color D93F0B --description "Developer experience issue" 2>/dev/null || true
-gh label create widget-gap --color 5319E7 --description "Missing widget request"     2>/dev/null || true
-gh label create tuner      --color FBCA04 --description "Tuner-related"              2>/dev/null || true
-gh label create stale      --color CCCCCC --description "Outdated content"           2>/dev/null || true
-gh label create missing    --color EEEEEE --description "Missing coverage"           2>/dev/null || true
-gh label create upstream   --color BFD4F2 --description "Upstream Flutter limit"     2>/dev/null || true
+gh label create dogfood    --color 0E8A16 --description "Dogfood cycle issue"                 2>/dev/null || true
+gh label create bug        --color D73A4A --description "Something isn't working"              2>/dev/null || true
+gh label create feature    --color A2EEEF --description "New feature or request"               2>/dev/null || true
+gh label create docs       --color 0075CA --description "Improvements or additions to documentation" 2>/dev/null || true
+gh label create dx         --color D93F0B --description "Developer experience issue"           2>/dev/null || true
+gh label create widget-gap --color 5319E7 --description "Missing widget request"               2>/dev/null || true
+gh label create tuner      --color FBCA04 --description "Tuner-related"                        2>/dev/null || true
+gh label create stale      --color CCCCCC --description "Outdated content"                     2>/dev/null || true
+gh label create missing    --color EEEEEE --description "Missing coverage"                     2>/dev/null || true
+gh label create upstream   --color BFD4F2 --description "Upstream Flutter limit"               2>/dev/null || true
 ```
 
-`bug`, `feature`, `docs`는 GitHub 기본 라벨이라 존재 가정.
+`bug`, `feature`, `docs`는 GitHub 기본 제공 가정이 실제 빈 레포에선 깨지는 경우가 있어(cycle #1에서 확인), prereqs에서 idempotent로 함께 생성.
 
 ### 8.4 외부 기여자 필터 안내
 


### PR DESCRIPTION
## Summary

SKILL.md prereqs에 `bug`/`feature`/`docs` 라벨 idempotent 생성 추가. spec §8.3 본문도 동기화.

## Why

cycle #1 fix 중 발견: `bug`/`feature`/`docs`가 "GitHub 기본 제공"이라 가정했지만 fresh 저장소에선 실존하지 않는 경우가 있음. 첫 `gh issue create --label dogfood,feature` 실패로 드러남(이미 수동 생성해서 해결했지만 다음 사이클 재발 방지 차원).

색상·description은 GitHub 표준 기본값과 매치(`bug` #D73A4A, `feature` #A2EEEF, `docs` #0075CA).

## Test plan

- [x] `fvm flutter analyze` — clean
- [x] 재실행 시 이미 존재하는 라벨은 stderr로 에러 빠지지만 `|| true`로 ignore → idempotent 보장