### PR TITLE
feat: PixelTheme ThemeExtension system (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 (Unreleased)
 
 ### Added
+- `PixelTheme` / `PixelBoxTheme` / `PixelButtonTheme` — `ThemeExtension`-based pixel defaults. Wire once with `pixelUiTheme(...)` on `MaterialApp.theme` and any descendant `PixelBox` / `PixelButton` inherits its style (#8).
+- `pixelUiTheme({base, pixelTheme, boxTheme, buttonTheme})` factory returns a `ThemeData` with pixel extensions registered; explicit `boxTheme`/`buttonTheme` override slots on `pixelTheme`. Preserves unrelated extensions on `base`.
+- `context.pixelTheme<T>()` shorthand for `Theme.of(context).extension<T>()`.
+- `PixelShapePainterBuilder` typedef exported as a reserved slot on `PixelBoxTheme.painter` (wired in a future release).
 - `PixelButton.disabledStyle` optional parameter — explicit `PixelShapeStyle` shown when `onPressed` is `null`. Unspecified keeps the existing behavior (`normalStyle` rendered at 50% opacity).
+
+### Changed
+- `PixelBox.style` and `PixelButton.normalStyle` are now optional. When omitted they resolve from the ancestor theme; asserts if neither is available. Existing call sites that pass these props explicitly are unaffected.
 
 ## 0.2.1 — 2026-04-23
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,6 +49,8 @@ class _ShowcaseScreen extends StatelessWidget {
               _ButtonsShowcase(),
               _SectionDivider('4. Texture'),
               _TextureShowcase(),
+              _SectionDivider('5. Theme inheritance'),
+              _ThemeShowcase(),
               SizedBox(height: 40),
             ],
           ),
@@ -301,7 +303,55 @@ class _TextureShowcase extends StatelessWidget {
   }
 }
 
-/// Section 5 — hero composition for pub.dev screenshot #1.
+/// Section 5 — theme inheritance via `pixelUiTheme`.
+class _ThemeShowcase extends StatelessWidget {
+  const _ThemeShowcase();
+
+  @override
+  Widget build(BuildContext context) {
+    const themedStyle = PixelShapeStyle(
+      corners: PixelCorners.md,
+      fillColor: Color(0xFF3C6BE0),
+      borderColor: Color(0xFF1A3A80),
+      borderWidth: 1,
+    );
+    const overrideStyle = PixelShapeStyle(
+      corners: PixelCorners.md,
+      fillColor: Color(0xFFE07A3C),
+      borderColor: Color(0xFF8B3E1A),
+      borderWidth: 1,
+    );
+
+    return Theme(
+      data: pixelUiTheme(
+        base: Theme.of(context),
+        boxTheme: const PixelBoxTheme(style: themedStyle),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Row(
+          children: const [
+            _Labelled(
+              'inherits theme',
+              PixelBox(logicalWidth: 16, logicalHeight: 16),
+            ),
+            SizedBox(width: 24),
+            _Labelled(
+              'style prop wins',
+              PixelBox(
+                logicalWidth: 16,
+                logicalHeight: 16,
+                style: overrideStyle,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Section 6 — hero composition for pub.dev screenshot #1.
 class _HeroComposition extends StatelessWidget {
   const _HeroComposition();
 

--- a/lib/pixel_ui.dart
+++ b/lib/pixel_ui.dart
@@ -6,3 +6,4 @@ export 'src/pixel_button.dart';
 export 'src/pixel_shape_painter.dart';
 export 'src/pixel_style.dart';
 export 'src/pixel_text.dart';
+export 'src/pixel_theme.dart';

--- a/lib/src/pixel_box.dart
+++ b/lib/src/pixel_box.dart
@@ -1,17 +1,21 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import 'package:pixel_ui/src/pixel_shape_painter.dart';
 import 'package:pixel_ui/src/pixel_style.dart';
+import 'package:pixel_ui/src/pixel_theme.dart';
 
 /// Base pixel-shape container.
 ///
 /// Accepts any [child] widget. If only [width] or [height] is given, the other
 /// is computed from `logicalWidth / logicalHeight`. If neither is given,
 /// defaults to logical size × 4.
+///
+/// When [style] is omitted, falls back to `PixelBoxTheme.style` supplied via
+/// [pixelUiTheme]. Asserts if neither is available.
 class PixelBox extends StatelessWidget {
   final int logicalWidth;
   final int logicalHeight;
-  final PixelShapeStyle style;
+  final PixelShapeStyle? style;
 
   final double? width;
   final double? height;
@@ -25,7 +29,7 @@ class PixelBox extends StatelessWidget {
     super.key,
     required this.logicalWidth,
     required this.logicalHeight,
-    required this.style,
+    this.style,
     this.width,
     this.height,
     this.padding,
@@ -35,10 +39,18 @@ class PixelBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final resolved = style ?? context.pixelTheme<PixelBoxTheme>()?.style;
+    assert(
+      resolved != null,
+      'PixelBox requires a `style` prop or a `PixelBoxTheme.style` registered '
+      'via `pixelUiTheme(...)` on an ancestor Theme/MaterialApp.',
+    );
+    final shapeStyle = resolved!;
+
     final ratio = logicalWidth / logicalHeight;
     final (w, h) = _resolveSize(ratio);
 
-    final shadow = style.shadow;
+    final shadow = shapeStyle.shadow;
     final sox = shadow?.offset.dx.abs() ?? 0;
     final soy = shadow?.offset.dy.abs() ?? 0;
     final perPxW = w / logicalWidth;
@@ -56,9 +68,9 @@ class PixelBox extends StatelessWidget {
               painter: PixelShapePainter(
                 logicalWidth: logicalWidth,
                 logicalHeight: logicalHeight,
-                style: style,
+                style: shapeStyle,
               ),
-              isComplex: style.texture != null,
+              isComplex: shapeStyle.texture != null,
               willChange: false,
             ),
           ),

--- a/lib/src/pixel_button.dart
+++ b/lib/src/pixel_button.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import 'package:pixel_ui/src/pixel_box.dart';
 import 'package:pixel_ui/src/pixel_style.dart';
+import 'package:pixel_ui/src/pixel_theme.dart';
 
 /// Interactive pixel button with optional press-state and disabled-state styles.
 ///
@@ -10,11 +11,15 @@ import 'package:pixel_ui/src/pixel_style.dart';
 /// when [onPressed] is null (falling back to [normalStyle] rendered at 50%
 /// opacity if not provided). The child can be shifted down by
 /// [pressChildOffset] while pressed, simulating a button press.
+///
+/// When any style prop is omitted, falls back to the matching field on
+/// `PixelButtonTheme` supplied via [pixelUiTheme]. Asserts if [normalStyle]
+/// cannot be resolved from either source.
 class PixelButton extends StatefulWidget {
   final int logicalWidth;
   final int logicalHeight;
 
-  final PixelShapeStyle normalStyle;
+  final PixelShapeStyle? normalStyle;
 
   /// Style to show while pressed. `null` keeps [normalStyle].
   final PixelShapeStyle? pressedStyle;
@@ -43,7 +48,7 @@ class PixelButton extends StatefulWidget {
     super.key,
     required this.logicalWidth,
     required this.logicalHeight,
-    required this.normalStyle,
+    this.normalStyle,
     this.pressedStyle,
     this.disabledStyle,
     this.width,
@@ -66,19 +71,6 @@ class _PixelButtonState extends State<PixelButton> {
 
   bool get _enabled => widget.onPressed != null;
 
-  PixelShapeStyle get _currentStyle {
-    if (!_enabled && widget.disabledStyle != null) return widget.disabledStyle!;
-    if (_pressed && widget.pressedStyle != null) return widget.pressedStyle!;
-    return widget.normalStyle;
-  }
-
-  double get _opacity {
-    // Only dim when falling back to normalStyle in the disabled state;
-    // a custom disabledStyle already carries the author's intent.
-    if (!_enabled && widget.disabledStyle == null) return 0.5;
-    return 1.0;
-  }
-
   void _setPressed(bool v) {
     if (!_enabled) return;
     if (_pressed == v) return;
@@ -87,6 +79,20 @@ class _PixelButtonState extends State<PixelButton> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = context.pixelTheme<PixelButtonTheme>();
+    final normal = widget.normalStyle ?? theme?.normalStyle;
+    assert(
+      normal != null,
+      'PixelButton requires a `normalStyle` prop or a '
+      '`PixelButtonTheme.normalStyle` registered via `pixelUiTheme(...)` on '
+      'an ancestor Theme/MaterialApp.',
+    );
+    final pressed = widget.pressedStyle ?? theme?.pressedStyle;
+    final disabled = widget.disabledStyle ?? theme?.disabledStyle;
+
+    final currentStyle = _currentStyle(normal!, pressed, disabled);
+    final opacity = _resolveOpacity(disabled);
+
     return Semantics(
       button: true,
       enabled: _enabled,
@@ -99,11 +105,11 @@ class _PixelButtonState extends State<PixelButton> {
         onTapCancel: () => _setPressed(false),
         onTap: _enabled ? () => widget.onPressed!() : null,
         child: Opacity(
-          opacity: _opacity,
+          opacity: opacity,
           child: PixelBox(
             logicalWidth: widget.logicalWidth,
             logicalHeight: widget.logicalHeight,
-            style: _currentStyle,
+            style: currentStyle,
             width: widget.width,
             height: widget.height,
             padding: widget.padding,
@@ -123,5 +129,22 @@ class _PixelButtonState extends State<PixelButton> {
         ),
       ),
     );
+  }
+
+  PixelShapeStyle _currentStyle(
+    PixelShapeStyle normal,
+    PixelShapeStyle? pressed,
+    PixelShapeStyle? disabled,
+  ) {
+    if (!_enabled && disabled != null) return disabled;
+    if (_pressed && pressed != null) return pressed;
+    return normal;
+  }
+
+  double _resolveOpacity(PixelShapeStyle? disabled) {
+    // Only dim when no explicit disabled style is available; a custom
+    // disabledStyle already carries the author's intent.
+    if (!_enabled && disabled == null) return 0.5;
+    return 1.0;
   }
 }

--- a/lib/src/pixel_theme.dart
+++ b/lib/src/pixel_theme.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+
+import 'package:pixel_ui/src/pixel_style.dart';
+
+/// Signature for a user-supplied builder that produces a [CustomPainter]
+/// from a [PixelShapeStyle] and logical dimensions.
+///
+/// Reserved for the painter-injection feature (issue #9); exported here so
+/// that [PixelBoxTheme.painter] can hold it without a follow-up breaking
+/// change.
+typedef PixelShapePainterBuilder = CustomPainter Function({
+  required int logicalWidth,
+  required int logicalHeight,
+  required PixelShapeStyle style,
+});
+
+/// Theme overrides for [PixelBox].
+///
+/// `style` provides the default [PixelShapeStyle] for any [PixelBox] that
+/// omits its own `style` prop. `painter` is an inert slot in 0.3.0 and will
+/// be activated in #9.
+class PixelBoxTheme extends ThemeExtension<PixelBoxTheme> {
+  final PixelShapeStyle? style;
+  final PixelShapePainterBuilder? painter;
+
+  const PixelBoxTheme({this.style, this.painter});
+
+  @override
+  PixelBoxTheme copyWith({
+    PixelShapeStyle? style,
+    PixelShapePainterBuilder? painter,
+  }) {
+    return PixelBoxTheme(
+      style: style ?? this.style,
+      painter: painter ?? this.painter,
+    );
+  }
+
+  @override
+  PixelBoxTheme lerp(covariant ThemeExtension<PixelBoxTheme>? other, double t) {
+    if (other is! PixelBoxTheme) return this;
+    return t < 0.5 ? this : other;
+  }
+}
+
+/// Theme overrides for [PixelButton].
+class PixelButtonTheme extends ThemeExtension<PixelButtonTheme> {
+  final PixelShapeStyle? normalStyle;
+  final PixelShapeStyle? pressedStyle;
+  final PixelShapeStyle? disabledStyle;
+
+  const PixelButtonTheme({
+    this.normalStyle,
+    this.pressedStyle,
+    this.disabledStyle,
+  });
+
+  @override
+  PixelButtonTheme copyWith({
+    PixelShapeStyle? normalStyle,
+    PixelShapeStyle? pressedStyle,
+    PixelShapeStyle? disabledStyle,
+  }) {
+    return PixelButtonTheme(
+      normalStyle: normalStyle ?? this.normalStyle,
+      pressedStyle: pressedStyle ?? this.pressedStyle,
+      disabledStyle: disabledStyle ?? this.disabledStyle,
+    );
+  }
+
+  @override
+  PixelButtonTheme lerp(
+    covariant ThemeExtension<PixelButtonTheme>? other,
+    double t,
+  ) {
+    if (other is! PixelButtonTheme) return this;
+    return t < 0.5 ? this : other;
+  }
+}
+
+/// Umbrella extension grouping per-component pixel themes.
+///
+/// Used as a convenient entry point for [pixelUiTheme]; individual
+/// [PixelBoxTheme] / [PixelButtonTheme] extensions remain the source of
+/// truth resolved by widgets.
+class PixelTheme extends ThemeExtension<PixelTheme> {
+  final PixelBoxTheme? box;
+  final PixelButtonTheme? button;
+
+  const PixelTheme({this.box, this.button});
+
+  @override
+  PixelTheme copyWith({PixelBoxTheme? box, PixelButtonTheme? button}) {
+    return PixelTheme(
+      box: box ?? this.box,
+      button: button ?? this.button,
+    );
+  }
+
+  @override
+  PixelTheme lerp(covariant ThemeExtension<PixelTheme>? other, double t) {
+    if (other is! PixelTheme) return this;
+    return t < 0.5 ? this : other;
+  }
+}
+
+/// Builds a [ThemeData] with pixel_ui extensions registered.
+///
+/// Explicit [boxTheme] / [buttonTheme] take precedence over the matching
+/// slots of [pixelTheme]. Unrelated extensions on [base] are preserved.
+ThemeData pixelUiTheme({
+  ThemeData? base,
+  PixelTheme? pixelTheme,
+  PixelBoxTheme? boxTheme,
+  PixelButtonTheme? buttonTheme,
+}) {
+  final data = base ?? ThemeData();
+  final resolvedBox = boxTheme ?? pixelTheme?.box;
+  final resolvedButton = buttonTheme ?? pixelTheme?.button;
+
+  final preserved = Map<Object, ThemeExtension<dynamic>>.of(data.extensions)
+    ..remove(PixelTheme)
+    ..remove(PixelBoxTheme)
+    ..remove(PixelButtonTheme);
+  final merged = [
+    ...preserved.values,
+    ?pixelTheme,
+    ?resolvedBox,
+    ?resolvedButton,
+  ];
+
+  return data.copyWith(extensions: merged);
+}
+
+/// Convenience accessor: `context.pixelTheme<PixelBoxTheme>()`.
+extension PixelThemeContext on BuildContext {
+  T? pixelTheme<T extends ThemeExtension<T>>() => Theme.of(this).extension<T>();
+}

--- a/test/pixel_theme_test.dart
+++ b/test/pixel_theme_test.dart
@@ -1,0 +1,379 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pixel_ui/pixel_ui.dart';
+
+const _boxStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: Color(0xFFFF0000),
+);
+const _normalStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: Color(0xFF00AA00),
+);
+const _pressedStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: Color(0xFF007700),
+);
+const _disabledStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: Color(0xFF888888),
+);
+
+void main() {
+  group('PixelBoxTheme', () {
+    test('copyWith replaces style', () {
+      const a = PixelBoxTheme(style: _boxStyle);
+      final b = a.copyWith(style: _normalStyle);
+      expect(b.style, _normalStyle);
+    });
+
+    test('copyWith preserves omitted fields', () {
+      const a = PixelBoxTheme(style: _boxStyle);
+      final b = a.copyWith();
+      expect(b.style, _boxStyle);
+    });
+
+    test('lerp snaps at t=0.5', () {
+      const a = PixelBoxTheme(style: _boxStyle);
+      const b = PixelBoxTheme(style: _normalStyle);
+      expect(a.lerp(b, 0.0).style, _boxStyle);
+      expect(a.lerp(b, 0.49).style, _boxStyle);
+      expect(a.lerp(b, 0.5).style, _normalStyle);
+      expect(a.lerp(b, 1.0).style, _normalStyle);
+    });
+
+    test('lerp returns self when other is null', () {
+      const a = PixelBoxTheme(style: _boxStyle);
+      expect(a.lerp(null, 0.5), same(a));
+    });
+  });
+
+  group('PixelButtonTheme', () {
+    const a = PixelButtonTheme(
+      normalStyle: _normalStyle,
+      pressedStyle: _pressedStyle,
+      disabledStyle: _disabledStyle,
+    );
+
+    test('copyWith replaces one field', () {
+      final b = a.copyWith(pressedStyle: _boxStyle);
+      expect(b.normalStyle, _normalStyle);
+      expect(b.pressedStyle, _boxStyle);
+      expect(b.disabledStyle, _disabledStyle);
+    });
+
+    test('lerp snaps at t=0.5', () {
+      const other = PixelButtonTheme(normalStyle: _boxStyle);
+      final mid = a.lerp(other, 0.5);
+      expect(mid.normalStyle, _boxStyle);
+    });
+  });
+
+  group('PixelTheme (umbrella)', () {
+    test('copyWith replaces box and button', () {
+      const a = PixelTheme();
+      final b = a.copyWith(
+        box: const PixelBoxTheme(style: _boxStyle),
+        button: const PixelButtonTheme(normalStyle: _normalStyle),
+      );
+      expect(b.box?.style, _boxStyle);
+      expect(b.button?.normalStyle, _normalStyle);
+    });
+
+    test('lerp snaps children at t=0.5', () {
+      const a = PixelTheme(box: PixelBoxTheme(style: _boxStyle));
+      const b = PixelTheme(box: PixelBoxTheme(style: _normalStyle));
+      final mid = a.lerp(b, 0.6);
+      expect(mid.box?.style, _normalStyle);
+    });
+  });
+
+  group('pixelUiTheme factory', () {
+    test('registers three extensions on fresh ThemeData', () {
+      final theme = pixelUiTheme(
+        pixelTheme: const PixelTheme(),
+        boxTheme: const PixelBoxTheme(style: _boxStyle),
+        buttonTheme: const PixelButtonTheme(normalStyle: _normalStyle),
+      );
+      expect(theme.extension<PixelTheme>(), isNotNull);
+      expect(theme.extension<PixelBoxTheme>()?.style, _boxStyle);
+      expect(theme.extension<PixelButtonTheme>()?.normalStyle, _normalStyle);
+    });
+
+    test('preserves unrelated extensions on the base theme', () {
+      final base = ThemeData().copyWith(
+        extensions: const <ThemeExtension<dynamic>>[_MarkerExtension()],
+      );
+      final theme = pixelUiTheme(
+        base: base,
+        boxTheme: const PixelBoxTheme(style: _boxStyle),
+      );
+      expect(theme.extension<_MarkerExtension>(), isNotNull);
+      expect(theme.extension<PixelBoxTheme>(), isNotNull);
+    });
+
+    test('replaces existing pixel extensions on the base theme', () {
+      final base = pixelUiTheme(
+        boxTheme: const PixelBoxTheme(style: _boxStyle),
+      );
+      final overridden = pixelUiTheme(
+        base: base,
+        boxTheme: const PixelBoxTheme(style: _normalStyle),
+      );
+      expect(overridden.extension<PixelBoxTheme>()?.style, _normalStyle);
+    });
+
+    test('derives box/button from umbrella when explicit not given', () {
+      final theme = pixelUiTheme(
+        pixelTheme: const PixelTheme(
+          box: PixelBoxTheme(style: _boxStyle),
+          button: PixelButtonTheme(normalStyle: _normalStyle),
+        ),
+      );
+      expect(theme.extension<PixelBoxTheme>()?.style, _boxStyle);
+      expect(theme.extension<PixelButtonTheme>()?.normalStyle, _normalStyle);
+    });
+
+    test('explicit boxTheme overrides umbrella.box', () {
+      final theme = pixelUiTheme(
+        pixelTheme: const PixelTheme(box: PixelBoxTheme(style: _boxStyle)),
+        boxTheme: const PixelBoxTheme(style: _normalStyle),
+      );
+      expect(theme.extension<PixelBoxTheme>()?.style, _normalStyle);
+    });
+  });
+
+  group('context.pixelTheme<T>()', () {
+    testWidgets('resolves PixelBoxTheme from ancestor Theme', (tester) async {
+      late PixelBoxTheme? resolved;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: const PixelBoxTheme(style: _boxStyle),
+          ),
+          home: Builder(
+            builder: (context) {
+              resolved = context.pixelTheme<PixelBoxTheme>();
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(resolved?.style, _boxStyle);
+    });
+
+    testWidgets('returns null when extension absent', (tester) async {
+      late PixelBoxTheme? resolved;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              resolved = context.pixelTheme<PixelBoxTheme>();
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(resolved, isNull);
+    });
+  });
+
+  group('PixelBox theme pickup', () {
+    testWidgets('uses PixelBoxTheme.style when style prop omitted', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: const PixelBoxTheme(style: _boxStyle),
+          ),
+          home: const Center(
+            child: PixelBox(logicalWidth: 10, logicalHeight: 5),
+          ),
+        ),
+      );
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _boxStyle);
+    });
+
+    testWidgets('explicit style prop wins over theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: const PixelBoxTheme(style: _boxStyle),
+          ),
+          home: const Center(
+            child: PixelBox(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              style: _normalStyle,
+            ),
+          ),
+        ),
+      );
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _normalStyle);
+    });
+
+    testWidgets('asserts when both style prop and theme absent', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: PixelBox(logicalWidth: 10, logicalHeight: 5),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isAssertionError);
+    });
+  });
+
+  group('PixelButton theme pickup', () {
+    testWidgets('uses PixelButtonTheme.normalStyle when normalStyle prop omitted',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            buttonTheme: const PixelButtonTheme(normalStyle: _normalStyle),
+          ),
+          home: Center(
+            child: PixelButton(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              onPressed: () {},
+              child: const Text('x'),
+            ),
+          ),
+        ),
+      );
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _normalStyle);
+    });
+
+    testWidgets('inherits pressedStyle from theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            buttonTheme: const PixelButtonTheme(
+              normalStyle: _normalStyle,
+              pressedStyle: _pressedStyle,
+            ),
+          ),
+          home: Center(
+            child: PixelButton(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              onPressed: () {},
+              child: const Text('p'),
+            ),
+          ),
+        ),
+      );
+      final gesture = await tester.startGesture(tester.getCenter(find.byType(PixelButton)));
+      await tester.pump();
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _pressedStyle);
+      await gesture.up();
+    });
+
+    testWidgets('inherits disabledStyle from theme', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: _ThemeWrapper(
+            button: PixelButtonTheme(
+              normalStyle: _normalStyle,
+              disabledStyle: _disabledStyle,
+            ),
+            child: Center(
+              child: PixelButton(
+                logicalWidth: 10,
+                logicalHeight: 5,
+                onPressed: null,
+                child: Text('d'),
+              ),
+            ),
+          ),
+        ),
+      );
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _disabledStyle);
+    });
+
+    testWidgets('explicit normalStyle prop wins over theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            buttonTheme: const PixelButtonTheme(normalStyle: _disabledStyle),
+          ),
+          home: Center(
+            child: PixelButton(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              normalStyle: _normalStyle,
+              onPressed: () {},
+              child: const Text('x'),
+            ),
+          ),
+        ),
+      );
+      final painter = _pixelPainter(tester);
+      expect(painter.style, _normalStyle);
+    });
+
+    testWidgets('asserts when both normalStyle prop and theme absent',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: PixelButton(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              onPressed: () {},
+              child: const Text('x'),
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isAssertionError);
+    });
+  });
+}
+
+PixelShapePainter _pixelPainter(WidgetTester tester) {
+  final finder = find.descendant(
+    of: find.byType(PixelBox),
+    matching: find.byType(CustomPaint),
+  );
+  final paints = tester.widgetList<CustomPaint>(finder);
+  for (final paint in paints) {
+    final painter = paint.painter;
+    if (painter is PixelShapePainter) return painter;
+  }
+  throw StateError('No PixelShapePainter found in PixelBox subtree');
+}
+
+class _MarkerExtension extends ThemeExtension<_MarkerExtension> {
+  const _MarkerExtension();
+
+  @override
+  ThemeExtension<_MarkerExtension> copyWith() => this;
+
+  @override
+  ThemeExtension<_MarkerExtension> lerp(
+    covariant ThemeExtension<_MarkerExtension>? other,
+    double t,
+  ) =>
+      this;
+}
+
+class _ThemeWrapper extends StatelessWidget {
+  const _ThemeWrapper({required this.button, required this.child});
+
+  final PixelButtonTheme button;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: pixelUiTheme(buttonTheme: button),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces `PixelTheme` / `PixelBoxTheme` / `PixelButtonTheme` `ThemeExtension`s plus a `pixelUiTheme({base, pixelTheme, boxTheme, buttonTheme})` factory, so a single `MaterialApp(theme: pixelUiTheme(...))` wires defaults for every descendant `PixelBox` and `PixelButton`.
- `PixelBox.style` and `PixelButton.normalStyle` become optional — they resolve from the ancestor theme when omitted and assert loudly if neither source can supply one. All existing call sites that pass the props explicitly keep working unchanged.
- Reserves `PixelBoxTheme.painter` as a nullable slot (with the `PixelShapePainterBuilder` typedef exported) so #9 can wire painter-builder injection without a breaking change.
- Adds a "Theme inheritance" showcase to `example/lib/main.dart` and a `## 0.3.0 (Unreleased)` section to `CHANGELOG.md`.

Part of the v0.3.0 nes_ui absorb plan (see `docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md`). Processing order: **#8 → #9 → #11 → #10**, with a single version bump + publish after all four merge.

Closes #8.

## Test plan

- [x] `fvm flutter analyze` — clean (root, `example/`, `tuner/`)
- [x] `fvm flutter test --exclude-tags screenshot` — 109 passed (23 new `pixel_theme_test.dart` cases covering copyWith/lerp for the three extensions, `pixelUiTheme` merge/override/preservation semantics, `context.pixelTheme<T>()` resolution, and `PixelBox`/`PixelButton` theme pickup + fallback + assert paths)
- [x] `fvm dart pub publish --dry-run` — no package warnings beyond the expected "checked-in files modified" notice
- [ ] CI (`Test`, `Platform Build Matrix`) green on PR

## Follow-ups

- No `pubspec.yaml` version bump in this PR — batched with #9/#10/#11 into the `v0.3.0` tag push.
- `PixelBoxTheme.painter` is an inert slot until #9 activates it inside `PixelBox`.