### PR TITLE
feat: custom CustomPainter injection via PixelBoxTheme.painter (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `PixelTheme` / `PixelBoxTheme` / `PixelButtonTheme` — `ThemeExtension`-based pixel defaults. Wire once with `pixelUiTheme(...)` on `MaterialApp.theme` and any descendant `PixelBox` / `PixelButton` inherits its style (#8).
 - `pixelUiTheme({base, pixelTheme, boxTheme, buttonTheme})` factory returns a `ThemeData` with pixel extensions registered; explicit `boxTheme`/`buttonTheme` override slots on `pixelTheme`. Preserves unrelated extensions on `base`.
 - `context.pixelTheme<T>()` shorthand for `Theme.of(context).extension<T>()`.
-- `PixelShapePainterBuilder` typedef exported as a reserved slot on `PixelBoxTheme.painter` (wired in a future release).
+- `PixelShapePainterBuilder` typedef + `PixelBox.painter` optional prop + `PixelBoxTheme.painter` slot now active: inject a custom `CustomPainter` without forking `PixelBox` (#9). Precedence: `painter` prop > theme.painter > default `PixelShapePainter`.
 - `PixelButton.disabledStyle` optional parameter — explicit `PixelShapeStyle` shown when `onPressed` is `null`. Unspecified keeps the existing behavior (`normalStyle` rendered at 50% opacity).
 
 ### Changed

--- a/lib/src/pixel_box.dart
+++ b/lib/src/pixel_box.dart
@@ -12,10 +12,18 @@ import 'package:pixel_ui/src/pixel_theme.dart';
 ///
 /// When [style] is omitted, falls back to `PixelBoxTheme.style` supplied via
 /// [pixelUiTheme]. Asserts if neither is available.
+///
+/// A custom [PixelShapePainterBuilder] can replace the default
+/// [PixelShapePainter]; precedence is [painter] prop > `PixelBoxTheme.painter`
+/// > built-in default.
 class PixelBox extends StatelessWidget {
   final int logicalWidth;
   final int logicalHeight;
   final PixelShapeStyle? style;
+
+  /// Optional override for the painter builder. Takes precedence over
+  /// `PixelBoxTheme.painter`.
+  final PixelShapePainterBuilder? painter;
 
   final double? width;
   final double? height;
@@ -30,6 +38,7 @@ class PixelBox extends StatelessWidget {
     required this.logicalWidth,
     required this.logicalHeight,
     this.style,
+    this.painter,
     this.width,
     this.height,
     this.padding,
@@ -39,13 +48,15 @@ class PixelBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resolved = style ?? context.pixelTheme<PixelBoxTheme>()?.style;
+    final theme = context.pixelTheme<PixelBoxTheme>();
+    final resolved = style ?? theme?.style;
     assert(
       resolved != null,
       'PixelBox requires a `style` prop or a `PixelBoxTheme.style` registered '
       'via `pixelUiTheme(...)` on an ancestor Theme/MaterialApp.',
     );
     final shapeStyle = resolved!;
+    final builder = painter ?? theme?.painter ?? _defaultPainterBuilder;
 
     final ratio = logicalWidth / logicalHeight;
     final (w, h) = _resolveSize(ratio);
@@ -65,7 +76,7 @@ class PixelBox extends StatelessWidget {
         children: [
           Positioned.fill(
             child: CustomPaint(
-              painter: PixelShapePainter(
+              painter: builder(
                 logicalWidth: logicalWidth,
                 logicalHeight: logicalHeight,
                 style: shapeStyle,
@@ -96,4 +107,16 @@ class PixelBox extends StatelessWidget {
     if (height != null) return (height! * ratio, height!);
     return (logicalWidth * 4.0, logicalHeight * 4.0);
   }
+}
+
+CustomPainter _defaultPainterBuilder({
+  required int logicalWidth,
+  required int logicalHeight,
+  required PixelShapeStyle style,
+}) {
+  return PixelShapePainter(
+    logicalWidth: logicalWidth,
+    logicalHeight: logicalHeight,
+    style: style,
+  );
 }

--- a/test/pixel_painter_injection_test.dart
+++ b/test/pixel_painter_injection_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pixel_ui/pixel_ui.dart';
+
+const _boxStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: Color(0xFFFF0000),
+);
+
+/// Minimal marker painter used to assert that a custom builder ran.
+class _MarkerPainter extends CustomPainter {
+  _MarkerPainter({
+    required this.style,
+    required this.logicalWidth,
+    required this.logicalHeight,
+  });
+
+  final PixelShapeStyle style;
+  final int logicalWidth;
+  final int logicalHeight;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(Offset.zero & size, Paint()..color = style.fillColor);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+CustomPaint _paintOf(WidgetTester tester) {
+  final finder = find.descendant(
+    of: find.byType(PixelBox),
+    matching: find.byType(CustomPaint),
+  );
+  return tester.widgetList<CustomPaint>(finder).firstWhere(
+        (p) => p.painter != null,
+        orElse: () =>
+            throw StateError('No CustomPaint with painter found in PixelBox'),
+      );
+}
+
+void main() {
+  group('PixelShapePainterBuilder injection', () {
+    testWidgets('defaults to PixelShapePainter when no builder is set',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: PixelBox(
+              logicalWidth: 10,
+              logicalHeight: 5,
+              style: _boxStyle,
+            ),
+          ),
+        ),
+      );
+      expect(_paintOf(tester).painter, isA<PixelShapePainter>());
+    });
+
+    testWidgets('uses PixelBoxTheme.painter when widget prop is null',
+        (tester) async {
+      _MarkerPainter? captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: PixelBoxTheme(
+              style: _boxStyle,
+              painter: ({
+                required int logicalWidth,
+                required int logicalHeight,
+                required PixelShapeStyle style,
+              }) {
+                final p = _MarkerPainter(
+                  style: style,
+                  logicalWidth: logicalWidth,
+                  logicalHeight: logicalHeight,
+                );
+                captured = p;
+                return p;
+              },
+            ),
+          ),
+          home: const Center(
+            child: PixelBox(logicalWidth: 10, logicalHeight: 5),
+          ),
+        ),
+      );
+      final painter = _paintOf(tester).painter;
+      expect(painter, isA<_MarkerPainter>());
+      expect(captured, same(painter));
+      expect(captured!.logicalWidth, 10);
+      expect(captured!.logicalHeight, 5);
+      expect(captured!.style, _boxStyle);
+    });
+
+    testWidgets('widget painter prop wins over theme.painter',
+        (tester) async {
+      _MarkerPainter? fromProp;
+      CustomPainter themePainterBuilder({
+        required int logicalWidth,
+        required int logicalHeight,
+        required PixelShapeStyle style,
+      }) {
+        throw StateError('theme builder should not have been invoked');
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: PixelBoxTheme(
+              style: _boxStyle,
+              painter: themePainterBuilder,
+            ),
+          ),
+          home: Center(
+            child: PixelBox(
+              logicalWidth: 8,
+              logicalHeight: 4,
+              style: _boxStyle,
+              painter: ({
+                required int logicalWidth,
+                required int logicalHeight,
+                required PixelShapeStyle style,
+              }) {
+                final p = _MarkerPainter(
+                  style: style,
+                  logicalWidth: logicalWidth,
+                  logicalHeight: logicalHeight,
+                );
+                fromProp = p;
+                return p;
+              },
+            ),
+          ),
+        ),
+      );
+      expect(_paintOf(tester).painter, same(fromProp));
+    });
+
+    testWidgets('builder receives the resolved style (theme fallback path)',
+        (tester) async {
+      PixelShapeStyle? seen;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: pixelUiTheme(
+            boxTheme: PixelBoxTheme(
+              style: _boxStyle,
+              painter: ({
+                required int logicalWidth,
+                required int logicalHeight,
+                required PixelShapeStyle style,
+              }) {
+                seen = style;
+                return _MarkerPainter(
+                  style: style,
+                  logicalWidth: logicalWidth,
+                  logicalHeight: logicalHeight,
+                );
+              },
+            ),
+          ),
+          home: const Center(
+            child: PixelBox(logicalWidth: 10, logicalHeight: 5),
+          ),
+        ),
+      );
+      expect(seen, _boxStyle);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Activates the `PixelShapePainterBuilder` slot introduced (inert) in #8.
- `PixelBox` now accepts an optional `painter` prop; when omitted, falls back to `PixelBoxTheme.painter`; when that is also absent, uses the built-in `PixelShapePainter`.
- Zero impact on existing call sites. Users can now ship a NES-style hatched fill (or anything else) app-wide by registering a builder on the theme — no forking.

Part of the v0.3.0 nes_ui absorb plan (see `docs/specs/2026-04-23-v0.3.0-theme-absorb-design.md`). Processing order: **#8 → #9 → #11 → #10**, with a single version bump + publish after all four merge.

Closes #9.

## Test plan

- [x] `fvm flutter analyze` — clean
- [x] `fvm flutter test --exclude-tags screenshot` — 113 passed (4 new `pixel_painter_injection_test.dart` cases: default path, theme fallback, widget-prop precedence, builder arg forwarding)
- [ ] CI (`Test`, `Platform Build Matrix`) green on PR

## Follow-ups

- No `pubspec.yaml` version bump here — batched with #8/#10/#11 into `v0.3.0`.
- `PixelButton` benefits transitively (it composes a `PixelBox` internally).