### PR TITLE
chore(ci): scope root analyze to the published package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,18 +30,10 @@ jobs:
           fi
           echo "Tag $GITHUB_REF_NAME matches pubspec.yaml version"
 
-      - name: Pub get (root package)
+      - name: Pub get
         run: flutter pub get
 
-      - name: Pub get (example)
-        run: flutter pub get
-        working-directory: example
-
-      - name: Pub get (tuner)
-        run: flutter pub get
-        working-directory: tuner
-
-      - name: Analyze (package)
+      - name: Analyze
         run: flutter analyze
 
       - name: Test (exclude screenshot goldens)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,14 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - dogfood_cycle_*/**
+    # Subpackages ship their own pubspec + their own analyze runs. Scoping
+    # the root analyzer here means `flutter analyze` at the repo root only
+    # covers the published package, so publish.yml doesn't need to
+    # `flutter pub get` inside tuner/example first. The subpackages stay
+    # covered by dedicated `Analyze (tuner)` / `Analyze (example)` steps
+    # in test.yml.
+    - example/**
+    - tuner/**
   language:
     strict-casts: true
     strict-inference: true


### PR DESCRIPTION
## Summary

Root-cause follow-up to the v0.3.0 first-publish failure: the real problem wasn't \"publish.yml forgot a pub get\" — it was that `flutter analyze` at the repo root descended into `tuner/` (a separate Flutter package with its own pubspec) and complained about unresolved `package:pixel_ui_tuner/...` imports whenever that package's `.dart_tool/` wasn't populated.

- `analysis_options.yaml`: add `example/**` and `tuner/**` to `analyzer.exclude`. The root analyzer now matches the pub.dev shipping surface — only the root package's code. Both subpackages are `publish_to: none` and therefore aren't part of the published artifact.
- `.github/workflows/publish.yml`: revert to a single `Pub get` + single `Analyze` step. The `Pub get (example)` / `Pub get (tuner)` workaround introduced as a hotfix during the v0.3.0 tag push is no longer needed.

Coverage stays intact: `test.yml` still runs dedicated `Analyze (tuner)` and `Analyze (example)` steps (each with their own cwd + pub get) on every PR and push to `main`, so tuner/example quality is gated before anything merges.

## Test plan

- [x] Reproduced the original failure mode locally: `rm -rf tuner/.dart_tool example/.dart_tool && fvm flutter analyze` — now reports `No issues found`, where previously it failed with 31 unresolved-import errors.
- [x] `fvm flutter test --exclude-tags screenshot` at root → 128 passed.
- [x] `cd tuner && fvm flutter test` → 24 passed.
- [ ] CI (`Test`, `Platform Build Matrix`) green on PR.

## Impact

- No code behavior changes.
- No effect on already-published v0.3.0.
- Next `v*.*.*` tag push exercises the slimmed-down publish.yml.