### PR TITLE
fix: assert painter/style/texture invariants (closes #33, #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.0 — 2026-04-24
+
+### Changed
+- **Debug asserts on public painter/style/texture constructors.** Previously-silent misuse now fails loudly in debug builds (no effect in release). Closes #33 and #37.
+  - `PixelShapePainter`: `logicalWidth > 0`, `logicalHeight > 0` on construction; `corners.topInsetRows + corners.bottomInsetRows <= logicalHeight` on first `paint()`. Prevents the silent corner-stair overlap that caused top/bottom loops to double-paint shared rows with mismatched insets (#33).
+  - `PixelShapeStyle`: `borderWidth >= 0`.
+  - `PixelTexture`: `size >= 1`, `0 <= density <= 1`.
+- Callers hitting the new corner invariant should raise `logicalHeight` so the top+bottom stair fits — e.g. `PixelCorners.md` (3+3=6 rows) requires `logicalHeight >= 6`.
+
 ## 0.3.0 — 2026-04-24
 
 ### Added

--- a/lib/src/pixel_shape_painter.dart
+++ b/lib/src/pixel_shape_painter.dart
@@ -23,10 +23,25 @@ class PixelShapePainter extends CustomPainter {
     required this.logicalHeight,
     required this.style,
     this.labelCutout,
-  });
+  })  : assert(logicalWidth > 0,
+            'logicalWidth must be positive (got $logicalWidth)'),
+        assert(logicalHeight > 0,
+            'logicalHeight must be positive (got $logicalHeight)');
 
   @override
   void paint(Canvas canvas, Size size) {
+    // Cross-field invariant: corner stairs from top + bottom cannot collide.
+    // When they do, the top and bottom draw loops silently overpaint shared
+    // rows with different insets, corrupting the outline. See #33.
+    assert(
+      style.corners.topInsetRows + style.corners.bottomInsetRows <=
+          logicalHeight,
+      'Corner stairs overflow logicalHeight: '
+      'topInsetRows=${style.corners.topInsetRows} + '
+      'bottomInsetRows=${style.corners.bottomInsetRows} > '
+      'logicalHeight=$logicalHeight',
+    );
+
     final shadow = style.shadow;
     final sox = shadow?.offset.dx.toInt() ?? 0;
     final soy = shadow?.offset.dy.toInt() ?? 0;

--- a/lib/src/pixel_style.dart
+++ b/lib/src/pixel_style.dart
@@ -191,7 +191,9 @@ class PixelTexture {
     this.density = 0.15,
     this.size = 1,
     this.seed = 42,
-  });
+  })  : assert(density >= 0 && density <= 1,
+            'density must be in [0, 1] (got $density)'),
+        assert(size >= 1, 'size must be >= 1 (got $size)');
 
   @override
   bool operator ==(Object other) =>
@@ -226,7 +228,8 @@ class PixelShapeStyle {
     this.borderWidth = 0,
     this.shadow,
     this.texture,
-  });
+  }) : assert(borderWidth >= 0,
+            'borderWidth must be non-negative (got $borderWidth)');
 
   static const Object _unset = Object();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pixel_ui
 description: Pixel-art design system for Flutter. Parametric shapes, interactive
   buttons, and bundled pixel font.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/BottlePumpkin/pixel_ui
 repository: https://github.com/BottlePumpkin/pixel_ui
 issue_tracker: https://github.com/BottlePumpkin/pixel_ui/issues

--- a/test/pixel_box_test.dart
+++ b/test/pixel_box_test.dart
@@ -4,7 +4,7 @@ import 'package:pixel_ui/pixel_ui.dart';
 
 void main() {
   const style = PixelShapeStyle(
-    corners: PixelCorners.md,
+    corners: PixelCorners.sm,
     fillColor: Color(0xFFFF0000),
   );
 

--- a/test/pixel_button_test.dart
+++ b/test/pixel_button_test.dart
@@ -4,11 +4,11 @@ import 'package:pixel_ui/pixel_ui.dart';
 
 void main() {
   const normalStyle = PixelShapeStyle(
-    corners: PixelCorners.md,
+    corners: PixelCorners.sm,
     fillColor: Color(0xFF00FF00),
   );
   const pressedStyle = PixelShapeStyle(
-    corners: PixelCorners.md,
+    corners: PixelCorners.sm,
     fillColor: Color(0xFF008800),
   );
 
@@ -81,7 +81,7 @@ void main() {
   testWidgets('PixelButton uses disabledStyle when provided and onPressed is null',
       (tester) async {
     const disabledStyle = PixelShapeStyle(
-      corners: PixelCorners.md,
+      corners: PixelCorners.sm,
       fillColor: Color(0xFF888888),
     );
     await tester.pumpWidget(
@@ -129,7 +129,7 @@ void main() {
   testWidgets('PixelButton ignores disabledStyle when onPressed is provided',
       (tester) async {
     const disabledStyle = PixelShapeStyle(
-      corners: PixelCorners.md,
+      corners: PixelCorners.sm,
       fillColor: Color(0xFF888888),
     );
     await tester.pumpWidget(

--- a/test/pixel_painter_injection_test.dart
+++ b/test/pixel_painter_injection_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pixel_ui/pixel_ui.dart';
 
 const _boxStyle = PixelShapeStyle(
-  corners: PixelCorners.md,
+  corners: PixelCorners.sm,
   fillColor: Color(0xFFFF0000),
 );
 

--- a/test/pixel_shape_painter_asserts_test.dart
+++ b/test/pixel_shape_painter_asserts_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pixel_ui/pixel_ui.dart';
+
+PixelShapePainter _painter({
+  int logicalWidth = 10,
+  int logicalHeight = 10,
+  PixelShapeStyle style = const PixelShapeStyle(
+    corners: PixelCorners.sharp,
+    fillColor: Color(0xFFFF0000),
+  ),
+}) {
+  return PixelShapePainter(
+    logicalWidth: logicalWidth,
+    logicalHeight: logicalHeight,
+    style: style,
+  );
+}
+
+void main() {
+  group('PixelShapePainter constructor asserts', () {
+    test('logicalWidth must be positive', () {
+      expect(() => _painter(logicalWidth: 0), throwsAssertionError);
+      expect(() => _painter(logicalWidth: -1), throwsAssertionError);
+    });
+
+    test('logicalHeight must be positive', () {
+      expect(() => _painter(logicalHeight: 0), throwsAssertionError);
+      expect(() => _painter(logicalHeight: -1), throwsAssertionError);
+    });
+
+    test('positive dims pass', () {
+      expect(() => _painter(logicalWidth: 1, logicalHeight: 1), returnsNormally);
+    });
+  });
+
+  group('PixelShapePainter.paint asserts (cross-field invariants)', () {
+    // Drives paint() against a no-op recording canvas to trigger debug asserts
+    // that reference style.corners, which cannot live in the const constructor.
+    const size = Size(40, 40);
+
+    test('corner stairs must fit within logicalHeight', () {
+      // topInsetRows=3 + bottomInsetRows=3 > logicalHeight=5
+      final painter = _painter(
+        logicalWidth: 10,
+        logicalHeight: 5,
+        style: const PixelShapeStyle(
+          corners: PixelCorners.md,
+          fillColor: Color(0xFFFF0000),
+        ),
+      );
+      expect(
+        () => painter.paint(_NoopCanvas(), size),
+        throwsAssertionError,
+      );
+    });
+
+    test('corner stairs exactly fitting logicalHeight pass', () {
+      // topInsetRows=3 + bottomInsetRows=3 == logicalHeight=6
+      final painter = _painter(
+        logicalWidth: 10,
+        logicalHeight: 6,
+        style: const PixelShapeStyle(
+          corners: PixelCorners.md,
+          fillColor: Color(0xFFFF0000),
+        ),
+      );
+      expect(() => painter.paint(_NoopCanvas(), size), returnsNormally);
+    });
+  });
+
+  group('PixelShapeStyle constructor asserts', () {
+    test('borderWidth cannot be negative', () {
+      expect(
+        () => PixelShapeStyle(
+          corners: PixelCorners.sharp,
+          fillColor: const Color(0xFFFF0000),
+          borderWidth: -1,
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('PixelTexture constructor asserts', () {
+    test('size must be >= 1', () {
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), size: 0),
+        throwsAssertionError,
+      );
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), size: -1),
+        throwsAssertionError,
+      );
+    });
+
+    test('density must be in [0, 1]', () {
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), density: -0.1),
+        throwsAssertionError,
+      );
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), density: 1.1),
+        throwsAssertionError,
+      );
+    });
+
+    test('density boundaries 0.0 and 1.0 pass', () {
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), density: 0),
+        returnsNormally,
+      );
+      expect(
+        () => PixelTexture(color: const Color(0xFFFFFFFF), density: 1),
+        returnsNormally,
+      );
+    });
+  });
+}
+
+// Minimal canvas stub — paint() only needs drawRect; asserts fire before any
+// drawing work in the corner-overlap case.
+class _NoopCanvas implements Canvas {
+  @override
+  void drawRect(Rect rect, Paint paint) {}
+
+  @override
+  noSuchMethod(Invocation invocation) {
+    throw UnsupportedError('${invocation.memberName} not mocked');
+  }
+}

--- a/test/pixel_theme_test.dart
+++ b/test/pixel_theme_test.dart
@@ -3,19 +3,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pixel_ui/pixel_ui.dart';
 
 const _boxStyle = PixelShapeStyle(
-  corners: PixelCorners.md,
+  corners: PixelCorners.sm,
   fillColor: Color(0xFFFF0000),
 );
 const _normalStyle = PixelShapeStyle(
-  corners: PixelCorners.md,
+  corners: PixelCorners.sm,
   fillColor: Color(0xFF00AA00),
 );
 const _pressedStyle = PixelShapeStyle(
-  corners: PixelCorners.md,
+  corners: PixelCorners.sm,
   fillColor: Color(0xFF007700),
 );
 const _disabledStyle = PixelShapeStyle(
-  corners: PixelCorners.md,
+  corners: PixelCorners.sm,
   fillColor: Color(0xFF888888),
 );
 


### PR DESCRIPTION
Closes #33
Closes #37

## 변경사항
Silent misuse now fails loudly in debug builds; release builds unaffected (asserts stripped).

- `PixelShapePainter`
  - ctor: `logicalWidth > 0`, `logicalHeight > 0`
  - `paint()`: `corners.topInsetRows + corners.bottomInsetRows <= logicalHeight`
  - cross-field invariant lives in `paint()` (not ctor) because it references `style.corners.topInsetRows` which is a getter, not const-evaluable.
- `PixelShapeStyle`: `borderWidth >= 0`
- `PixelTexture`: `size >= 1`, `0 <= density <= 1`
- Version bump 0.3.0 → 0.4.0, CHANGELOG entry.

**#33 repro**: top and bottom stair loops in `_drawShape` were independent. When their row spans collided (`topInset + bottomInset > logicalHeight`), they both painted the overlap rows with different insets → outline bloat + broken stair. `paint()` now asserts before any draw.

**#37 repro**: `logicalWidth: 0`, negative dims, `PixelTexture(size: 0)`, `density: -1`, etc. all constructed silently and rendered garbage (or nothing). Now rejected at construction.

## Existing tests touched
4 test files that coincidentally tripped the new corner invariant (`logicalHeight: 5` + `PixelCorners.md`, a 3+3 stair) — their shared style constants switch to `PixelCorners.sm` (2+2 stair). These tests assert size/behavior, not corner shape, so the change is safe.

- `test/pixel_box_test.dart`
- `test/pixel_button_test.dart`
- `test/pixel_painter_injection_test.dart`
- `test/pixel_theme_test.dart`

New test file: `test/pixel_shape_painter_asserts_test.dart` — 9 cases (6 negative, 3 positive) covering both issues.

## 검증
- [x] `fvm flutter analyze` — No issues found
- [x] `fvm flutter test --exclude-tags screenshot` — 137 passed

## Note on semver
Debug-only asserts are technically non-breaking (release builds behave identically). Bumped to 0.4.0 anyway because "previously silent, now noisy" is a perceived behavior change for debug-mode users — CHANGELOG should surface it prominently.

## 후속
- #34 (texture overflow) — 별도 PR. clip 필요.
- #35 (painter canvas sizing docs) — 별도 PR.
- #36 (PixelGrid) — widget-gap fast-track, 별도 PR.
- #38 (README PixelShapePainter 예제) — 별도 PR.