### PR TITLE
docs: PixelShapePainter direct-use guide + canvasSizeFor helper (closes #35, #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.1 — 2026-04-24
+
+### Added
+- `PixelShapePainter.canvasSizeFor(...)` static helper — computes the `CustomPaint.size` needed to fit the shape plus its drop shadow at a given scale. Closes #35 for direct-use callers that previously had to reverse-engineer `PixelBox` internals to size the canvas correctly.
+
+### Docs
+- Class-level dartdoc on `PixelShapePainter` now documents canvas sizing (including the shadow-aware formula) and links to the new helper.
+- README `## Usage` gains a "Direct CustomPaint integration" subsection with a full minimap/tile-grid-style example (#38).
+- README `## Install` version pin bumped `^0.2.0` → `^0.4.0` to match the current minor line (recurring drift; see #19).
+
 ## 0.4.0 — 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pixel-art design system for Flutter — parametric shapes, interactive buttons, 
 
 ```yaml
 dependencies:
-  pixel_ui: ^0.2.0
+  pixel_ui: ^0.4.0
 ```
 
 ## Quick Start
@@ -146,6 +146,43 @@ PixelShapeStyle(
 ```
 
 Textures use a deterministic LCG so identical settings produce identical patterns across platforms and builds.
+
+### Direct CustomPaint integration
+
+For custom compositions that `PixelBox` doesn't cover — minimaps, tile
+grids, procedural layouts — use `PixelShapePainter` inside your own
+`CustomPaint`. Size the canvas with the shadow-aware helper so drop
+shadows never get clipped:
+
+```dart
+import 'package:pixel_ui/pixel_ui.dart';
+
+final style = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: const Color(0xFF5A8A3A),
+  shadow: PixelShadow.md(const Color(0xFF1A3010)),
+);
+
+CustomPaint(
+  size: PixelShapePainter.canvasSizeFor(
+    style: style,
+    logicalWidth: 16,
+    logicalHeight: 16,
+    scale: 4, // default — screen pixels per logical pixel
+  ),
+  painter: PixelShapePainter(
+    logicalWidth: 16,
+    logicalHeight: 16,
+    style: style,
+  ),
+)
+```
+
+The helper returns `(logicalWidth × scale, logicalHeight × scale)` when
+there's no shadow, and expands by `|shadow.offset|` on each axis
+otherwise. If you compute canvas size yourself, mirror the formula:
+`(logicalWidth + |shadow.offset.dx|) × scale` wide by
+`(logicalHeight + |shadow.offset.dy|) × scale` tall.
 
 ### Typography
 

--- a/lib/src/pixel_shape_painter.dart
+++ b/lib/src/pixel_shape_painter.dart
@@ -4,9 +4,46 @@ import 'package:pixel_ui/src/pixel_style.dart';
 
 /// Low-level CustomPainter for pixel shapes.
 ///
+/// Use this directly inside a [CustomPaint] when you want low-level
+/// composition (minimaps, tile grids, procedural layouts) that
+/// [PixelBox] doesn't cover. For the common case of a standalone shape
+/// with an inner child, prefer [PixelBox].
+///
+/// ## Canvas sizing
+///
+/// The painter paints the shape plus its drop shadow, so the surrounding
+/// [CustomPaint.size] should include the shadow extent:
+///
+/// ```
+/// width  = (logicalWidth  + |shadow.offset.dx|) * scale
+/// height = (logicalHeight + |shadow.offset.dy|) * scale
+/// ```
+///
+/// where `scale` is your target logical-to-screen pixel ratio (the built-in
+/// [PixelBox] uses `4`). Use [PixelShapePainter.canvasSizeFor] as a helper:
+///
+/// ```dart
+/// CustomPaint(
+///   size: PixelShapePainter.canvasSizeFor(
+///     style: style,
+///     logicalWidth: 16,
+///     logicalHeight: 16,
+///     scale: 4,
+///   ),
+///   painter: PixelShapePainter(
+///     logicalWidth: 16,
+///     logicalHeight: 16,
+///     style: style,
+///   ),
+/// )
+/// ```
+///
+/// If [PixelShapeStyle.shadow] is null, the helper returns
+/// `(logicalWidth * scale, logicalHeight * scale)`.
+///
+/// ## Other notes
+///
 /// - Takes a single [PixelShapeStyle] for `shouldRepaint` optimization.
-/// - [logicalWidth]/[logicalHeight] is the "design-basis pixel count"; actual
-///   render size auto-scales to match the composed canvas size.
 /// - Texture uses a deterministic LCG (1664525, 1013904223) so identical
 ///   settings always produce the same pattern across platforms/builds.
 class PixelShapePainter extends CustomPainter {
@@ -27,6 +64,28 @@ class PixelShapePainter extends CustomPainter {
             'logicalWidth must be positive (got $logicalWidth)'),
         assert(logicalHeight > 0,
             'logicalHeight must be positive (got $logicalHeight)');
+
+  /// Returns the [CustomPaint.size] a direct-use painter needs to fit the
+  /// shape's [logicalWidth] × [logicalHeight] grid plus any drop shadow, at
+  /// the given `scale` (logical pixels → screen pixels).
+  ///
+  /// Equivalent to what [PixelBox] computes internally. Returns
+  /// `(logicalWidth * scale, logicalHeight * scale)` when `style.shadow` is
+  /// null.
+  static Size canvasSizeFor({
+    required PixelShapeStyle style,
+    required int logicalWidth,
+    required int logicalHeight,
+    double scale = 4,
+  }) {
+    final shadow = style.shadow;
+    final sox = shadow?.offset.dx.abs() ?? 0;
+    final soy = shadow?.offset.dy.abs() ?? 0;
+    return Size(
+      (logicalWidth + sox) * scale,
+      (logicalHeight + soy) * scale,
+    );
+  }
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pixel_ui
 description: Pixel-art design system for Flutter. Parametric shapes, interactive
   buttons, and bundled pixel font.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/BottlePumpkin/pixel_ui
 repository: https://github.com/BottlePumpkin/pixel_ui
 issue_tracker: https://github.com/BottlePumpkin/pixel_ui/issues

--- a/test/pixel_shape_painter_canvas_size_test.dart
+++ b/test/pixel_shape_painter_canvas_size_test.dart
@@ -1,0 +1,86 @@
+// Tests for PixelShapePainter.canvasSizeFor — the helper introduced
+// alongside the dartdoc expansion for #35.
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pixel_ui/pixel_ui.dart';
+
+const _baseStyle = PixelShapeStyle(
+  corners: PixelCorners.sharp,
+  fillColor: Color(0xFFFF0000),
+);
+
+void main() {
+  group('PixelShapePainter.canvasSizeFor', () {
+    test('no shadow → logical × scale', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle,
+        logicalWidth: 16,
+        logicalHeight: 16,
+        scale: 4,
+      );
+      expect(size, const Size(64, 64));
+    });
+
+    test('positive shadow offset extends both axes', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle.copyWith(
+          shadow: PixelShadow.md(const Color(0xFF000000)), // (2, 2)
+        ),
+        logicalWidth: 16,
+        logicalHeight: 16,
+        scale: 4,
+      );
+      expect(size, const Size(72, 72)); // (16+2)*4
+    });
+
+    test('negative shadow offset uses absolute value', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle.copyWith(
+          shadow: const PixelShadow(
+            offset: Offset(-3, -1),
+            color: Color(0xFF000000),
+          ),
+        ),
+        logicalWidth: 10,
+        logicalHeight: 10,
+        scale: 4,
+      );
+      expect(size, const Size(52, 44)); // (10+3)*4, (10+1)*4
+    });
+
+    test('scale defaults to 4 (matches PixelBox convention)', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle,
+        logicalWidth: 5,
+        logicalHeight: 5,
+      );
+      expect(size, const Size(20, 20));
+    });
+
+    test('custom scale honored', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle,
+        logicalWidth: 8,
+        logicalHeight: 4,
+        scale: 2.5,
+      );
+      expect(size, const Size(20, 10));
+    });
+
+    test('asymmetric shadow offsets', () {
+      final size = PixelShapePainter.canvasSizeFor(
+        style: _baseStyle.copyWith(
+          shadow: const PixelShadow(
+            offset: Offset(4, -1),
+            color: Color(0xFF000000),
+          ),
+        ),
+        logicalWidth: 16,
+        logicalHeight: 16,
+        scale: 4,
+      );
+      expect(size, const Size(80, 68)); // (16+4)*4, (16+1)*4
+    });
+  });
+}


### PR DESCRIPTION
Closes #35
Closes #38

## 변경사항

`PixelShapePainter` is publicly exported but was invisible in docs (README: 0 mentions) and its dartdoc left canvas sizing unspecified — direct-use callers had to reverse-engineer `PixelBox` internals to size the canvas correctly when a shadow was involved.

- **Class dartdoc**: now documents canvas sizing formula + worked example.
- **New helper `PixelShapePainter.canvasSizeFor(...)`**: static method returning the `CustomPaint.size` given style/dims/scale. Shadow-aware.
- **README `## Usage`**: new "Direct CustomPaint integration" subsection with a complete example that uses the helper.

### Drive-by
README Install pin bumped `^0.2.0` → `^0.4.0`. Same recurring staleness pattern flagged in #19 (closed cycle #1) — caret drift since 0.3.0. Worth considering a pubspec-version-sync script as a follow-up.

### Scope
Non-breaking, docs + optional helper only. `0.4.0` → `0.4.1` patch bump.

## 검증
- [x] `fvm flutter analyze` — clean
- [x] `fvm flutter test --exclude-tags screenshot` — 145 passed

Tests added: `test/pixel_shape_painter_canvas_size_test.dart` — 6 cases (no shadow, positive offset, negative offset using abs, default scale, custom scale, asymmetric offsets).

## 후속
- #36 (PixelGrid widget-gap) — separate PR, needs brainstorming on API + 8-item checklist.