### PR TITLE
chore(ci): bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             target: windows
             command: flutter build windows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.7'

--- a/.github/workflows/deploy-tuner.yml
+++ b/.github/workflows/deploy-tuner.yml
@@ -27,7 +27,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.7'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write   # pub.dev OIDC
       contents: write   # gh release create
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dart-lang/setup-dart@v1
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Analyze + Test + Publish dry-run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.32.7'


### PR DESCRIPTION
## 변경사항
`actions/checkout@v4` → `actions/checkout@v5` 일괄 적용 (4개 workflow):
- `.github/workflows/build.yml`
- `.github/workflows/deploy-tuner.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/test.yml`

## 이유
최근 publish.yml 실행에서 GitHub가 Node.js 20 deprecation 경고를 출력:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

`actions/checkout@v5`는 Node 24 기반 첫 release. v4와 API 호환 drop-in.

## 처리하지 않은 항목 (deferred)
다른 액션들도 점검 대상이지만 현재 deprecation 경고는 없어 보수적으로 유지:
- `subosito/flutter-action@v2`
- `dart-lang/setup-dart@v1`
- `actions/configure-pages@v4`
- `actions/upload-pages-artifact@v3`
- `actions/deploy-pages@v4`

각자 자체 deprecation 통지 시 별도 PR.

## 검증
- 코드 변경 없음 (workflow YAML만)
- 머지 시 모든 CI 워크플로(test.yml + build.yml × 6 platforms + publish dry-run)가 v5 checkout으로 재실행됨 → 정상 동작 확인 가능
- 머지 후 첫 push가 자동 게이트 역할

## 영향
- 코드: 없음
- CI: 액션 업그레이드만
- 사용자: 0