### PR TITLE
docs: refine positioning for pub.dev discoverability (closes #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.1 — 2026-04-27
+
+### Docs
+- Refined positioning copy on `pubspec.yaml` description and README intro to surface `retro`, `8-bit`, `RPG`, `tile grids`, and `game UI` keywords for pub.dev search discoverability (#42).
+- New "Why pixel_ui?" section in README distinguishing the primitives-first model from full-themed widget sets (NES/XP/Steam-style).
+- `PixelGrid<T>` now listed in the Features summary.
+
 ## 0.5.0 — 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Platform Build](https://github.com/BottlePumpkin/pixel_ui/actions/workflows/build.yml/badge.svg)](https://github.com/BottlePumpkin/pixel_ui/actions/workflows/build.yml)
 [![Live Tuner](https://img.shields.io/badge/Live-Tuner-5A8A3A.svg)](https://bottlepumpkin.github.io/pixel_ui/)
 
-Pixel-art design system for Flutter — parametric shapes, interactive buttons, and a bundled pixel font.
+Pixel-art design system for Flutter — build retro, 8-bit, RPG-style game UIs with parametric shapes, tile grids, interactive buttons, pixel drop shadows, and a bundled pixel font.
 
 **🎨 [Try the PixelShapeStyle tuner →](https://bottlepumpkin.github.io/pixel_ui/)**
 
@@ -18,8 +18,21 @@ Pixel-art design system for Flutter — parametric shapes, interactive buttons, 
 - Deterministic LCG texture overlays
 - Pixel-aware drop shadows with `.sm`/`.md`/`.lg` factories
 - Press-state–aware interactive pixel buttons (`PixelButton`)
+- Tile-grid layout widget (`PixelGrid<T>`) for minimaps, inventories, and tile maps — with keyboard focus and drag-and-drop
 - Bundled Mulmaru pixel font (SIL OFL 1.1) with a ready-made `TextStyle` factory
 - Zero external dependencies beyond the Flutter SDK
+
+## Why pixel_ui?
+
+Most Flutter pixel/retro packages ship a complete themed widget set tied to
+a specific era (NES, Windows XP, Steam). `pixel_ui` is positioned
+differently: it provides **low-level pixel primitives**
+(`PixelShapePainter`, `PixelCorners`, `PixelShadow`, `PixelTexture`) plus a
+small set of opinionated composite widgets (`PixelBox`, `PixelButton`,
+`PixelGrid`, `PixelText`) and a **bundled pixel font**. Compose
+inventories, minimaps, dialog frames, HP bars, and tile maps from
+primitives that fit your art direction — instead of inheriting someone
+else's chrome.
 
 ## Platforms
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pixel_ui
-description: Pixel-art design system for Flutter. Parametric shapes, interactive
-  buttons, and bundled pixel font.
-version: 0.5.0
+description: Pixel-art design system for Flutter — retro / 8-bit primitives,
+  tile grids, interactive buttons, and a bundled pixel font for game UI.
+version: 0.5.1
 homepage: https://github.com/BottlePumpkin/pixel_ui
 repository: https://github.com/BottlePumpkin/pixel_ui
 issue_tracker: https://github.com/BottlePumpkin/pixel_ui/issues


### PR DESCRIPTION
Closes #42

## 변경사항

pub.dev `pixel` 검색에서 pixel_ui가 상위에 안 보이는 문제. Pub Points는 이미 160/160, popularity는 외부 활동 영역 → 패키지 코드 안에서 즉시 가능한 단기 항목 처리.

### pubspec.yaml description
- 99 → 145 chars
- 추가 키워드: `retro`, `8-bit`, `tile grids`, `game UI`
- pub.dev recommended 60–180 cap 안에 안전하게 위치

### README intro
- "Pixel-art design system for Flutter — parametric shapes, interactive buttons, and a bundled pixel font."
- → "Pixel-art design system for Flutter — build retro, 8-bit, RPG-style game UIs with parametric shapes, tile grids, interactive buttons, pixel drop shadows, and a bundled pixel font."

### README "Why pixel_ui?" 신규 섹션
경쟁 패키지(NES/XP/Steam 테마)와의 차별점을 명시: pixel_ui는 era-locked 테마 위젯셋이 아니라 **primitive 중심**.

### Features 보강
`PixelGrid<T>`가 0.5.0에서 추가됐는데 Features 리스트에 빠져 있었음 → 추가.

### 버전 bump
0.5.0 → 0.5.1. pub.dev는 publish 시점에 README + description을 재인덱싱하므로 효과 보려면 새 publish 필요.

## 처리하지 않은 항목 (이슈에 기록)
장기 popularity 항목은 외부 활동:
- 블로그 포스트, awesome-flutter PR, Flutter Discord 공유
- YouTube 데모/튜토리얼
- 유저 acquisition을 통한 likes·downloads 자연 증가

## 검증
- [x] `fvm flutter analyze` — clean
- [x] `fvm flutter test --exclude-tags screenshot` — 163 passed
- [x] description 145 chars (180 cap 안)
- [x] 5개 topics 그대로 유지 (pub.dev 5개 cap)