### PR TITLE
fix: guard README install pin against pubspec version drift (closes #50)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           channel: 'stable'
       - name: Pub get (root package)
         run: flutter pub get
+      - name: Check README install pin matches pubspec version
+        run: dart run tool/check_readme_version.dart
       - name: Pub get (example)
         run: flutter pub get
         working-directory: example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Docs
+- README `## Install` version pin bumped `^0.4.0` → `^0.5.0` to match the current minor line (recurring drift; closes #50, follow-up to #19).
+
+### Internal
+- `tool/check_readme_version.dart` — CI guard that fails when `README.md`'s `pixel_ui: ^X.Y` install pin falls behind `pubspec.yaml`'s `version:` major.minor. Wired into `.github/workflows/test.yml` to prevent the recurring drift pattern at PR-time. Supports `--fix` for one-shot local repair and `--json` for tooling.
+
 ## 0.5.1 — 2026-04-27
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ else's chrome.
 
 ```yaml
 dependencies:
-  pixel_ui: ^0.4.0
+  pixel_ui: ^0.5.0
 ```
 
 ## Quick Start

--- a/tool/check_readme_version.dart
+++ b/tool/check_readme_version.dart
@@ -1,0 +1,266 @@
+// tool/check_readme_version.dart
+//
+// Guards against the recurring "README install pin lags pubspec version"
+// drift (cycle #1 #19, cycle #3 #50). Runs in CI on every PR/push and
+// fails the build when the README pin's major.minor falls behind the
+// pubspec version's major.minor.
+//
+// Usage:
+//   dart run tool/check_readme_version.dart           # check, exit 1 if drift
+//   dart run tool/check_readme_version.dart --json    # machine-readable
+//   dart run tool/check_readme_version.dart --fix     # auto-update README
+//
+// Exit codes:
+//   0 — no drift (or drift was fixed in --fix mode)
+//   1 — drift detected (and --fix not passed)
+//   2 — required path missing or unparseable
+//
+// Drift rule:
+//   README pin's `^X.Y.Z?` constraint must satisfy pubspec's current
+//   `version: A.B.C`. Concretely: README's (major, minor) must equal
+//   pubspec's (major, minor). A pin like `^0.5.0` covers all of 0.5.x
+//   (caret semantics), so we don't require the patch to match.
+//
+//   Pre-1.0 caveat: under semver-pre-1.0, `^0.5.0` does NOT cover 0.6.0.
+//   So a pubspec at 0.6.0 with README pinned at `^0.5.0` IS drift.
+
+import 'dart:convert';
+import 'dart:io';
+
+const String pubspecPath = 'pubspec.yaml';
+const String readmePath = 'README.md';
+
+// Matches `pixel_ui: ^X.Y` or `pixel_ui: ^X.Y.Z` inside a fenced code block.
+// We anchor on the package name to avoid matching unrelated lines.
+final RegExp _readmePinRe = RegExp(
+  r'pixel_ui:\s*\^(\d+)\.(\d+)(?:\.(\d+))?',
+);
+
+final RegExp _pubspecVersionRe = RegExp(
+  r'^version:\s*(\d+)\.(\d+)\.(\d+)',
+  multiLine: true,
+);
+
+class _SemVer {
+  _SemVer(this.major, this.minor, [this.patch]);
+  final int major;
+  final int minor;
+  final int? patch;
+
+  String get caret => '^$major.$minor.${patch ?? 0}';
+  @override
+  String toString() => '$major.$minor${patch != null ? ".$patch" : ""}';
+}
+
+/// Returns null when the file is missing or no version line parses.
+_SemVer? _parsePubspecVersion(String pubspecSrc) {
+  final m = _pubspecVersionRe.firstMatch(pubspecSrc);
+  if (m == null) return null;
+  return _SemVer(
+    int.parse(m.group(1)!),
+    int.parse(m.group(2)!),
+    int.parse(m.group(3)!),
+  );
+}
+
+/// Returns the *first* `pixel_ui: ^X.Y[.Z]` pin found in README.
+_SemVer? _parseReadmePin(String readmeSrc) {
+  final m = _readmePinRe.firstMatch(readmeSrc);
+  if (m == null) return null;
+  return _SemVer(
+    int.parse(m.group(1)!),
+    int.parse(m.group(2)!),
+    m.group(3) == null ? null : int.parse(m.group(3)!),
+  );
+}
+
+bool _readmeCoversPubspec(_SemVer readme, _SemVer pubspec) {
+  // Pre-1.0 (major == 0): caret pins lock the minor. README's (major, minor)
+  // must equal pubspec's (major, minor).
+  if (readme.major == 0 && pubspec.major == 0) {
+    return readme.minor == pubspec.minor;
+  }
+  // 1.0+: caret pins lock the major. README's major must equal pubspec's
+  // major, and README's minor must be ≤ pubspec's minor (covers all 1.x ≥ pin).
+  return readme.major == pubspec.major && readme.minor <= pubspec.minor;
+}
+
+void main(List<String> args) {
+  final json = args.contains('--json');
+  final fix = args.contains('--fix');
+
+  final pubspecFile = File(pubspecPath);
+  final readmeFile = File(readmePath);
+
+  if (!pubspecFile.existsSync()) {
+    _emit(json, _Result.error('missing_pubspec', '$pubspecPath not found'));
+    exit(2);
+  }
+  if (!readmeFile.existsSync()) {
+    _emit(json, _Result.error('missing_readme', '$readmePath not found'));
+    exit(2);
+  }
+
+  final pubspecSrc = pubspecFile.readAsStringSync();
+  final readmeSrc = readmeFile.readAsStringSync();
+
+  final pubspec = _parsePubspecVersion(pubspecSrc);
+  if (pubspec == null) {
+    _emit(json,
+        _Result.error('unparseable_pubspec', 'no `version:` line in pubspec'));
+    exit(2);
+  }
+
+  final readme = _parseReadmePin(readmeSrc);
+  if (readme == null) {
+    _emit(
+      json,
+      _Result.error(
+        'missing_readme_pin',
+        'no `pixel_ui: ^X.Y[.Z]` pin found in $readmePath. '
+            'Add an Install snippet so this check can guard it.',
+      ),
+    );
+    exit(2);
+  }
+
+  if (_readmeCoversPubspec(readme, pubspec)) {
+    _emit(
+      json,
+      _Result.ok(
+        readme: readme,
+        pubspec: pubspec,
+        message: 'README pin ${readme.caret} covers pubspec $pubspec.',
+      ),
+    );
+    exit(0);
+  }
+
+  // Drift.
+  if (fix) {
+    final newPin = _SemVer(pubspec.major, pubspec.minor, 0);
+    final patched = readmeSrc.replaceFirst(
+      _readmePinRe,
+      'pixel_ui: ${newPin.caret}',
+    );
+    readmeFile.writeAsStringSync(patched);
+    _emit(
+      json,
+      _Result.fixed(
+        from: readme,
+        to: newPin,
+        pubspec: pubspec,
+      ),
+    );
+    exit(0);
+  }
+
+  _emit(
+    json,
+    _Result.drift(
+      readme: readme,
+      pubspec: pubspec,
+    ),
+  );
+  exit(1);
+}
+
+class _Result {
+  _Result._({
+    required this.kind,
+    this.code,
+    this.message,
+    this.readme,
+    this.pubspec,
+    this.fromPin,
+    this.toPin,
+  });
+
+  factory _Result.ok({
+    required _SemVer readme,
+    required _SemVer pubspec,
+    required String message,
+  }) =>
+      _Result._(
+        kind: 'ok',
+        readme: readme,
+        pubspec: pubspec,
+        message: message,
+      );
+
+  factory _Result.drift({
+    required _SemVer readme,
+    required _SemVer pubspec,
+  }) =>
+      _Result._(
+        kind: 'drift',
+        readme: readme,
+        pubspec: pubspec,
+      );
+
+  factory _Result.fixed({
+    required _SemVer from,
+    required _SemVer to,
+    required _SemVer pubspec,
+  }) =>
+      _Result._(
+        kind: 'fixed',
+        readme: to,
+        pubspec: pubspec,
+        fromPin: from,
+        toPin: to,
+      );
+
+  factory _Result.error(String code, String message) =>
+      _Result._(kind: 'error', code: code, message: message);
+
+  final String kind;
+  final String? code;
+  final String? message;
+  final _SemVer? readme;
+  final _SemVer? pubspec;
+  final _SemVer? fromPin;
+  final _SemVer? toPin;
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind,
+        if (code != null) 'code': code,
+        if (message != null) 'message': message,
+        if (readme != null) 'readme_pin': readme!.caret,
+        if (pubspec != null) 'pubspec_version': pubspec.toString(),
+        if (fromPin != null) 'fixed_from': fromPin!.caret,
+        if (toPin != null) 'fixed_to': toPin!.caret,
+      };
+}
+
+void _emit(bool json, _Result r) {
+  if (json) {
+    stdout.writeln(jsonEncode(r.toJson()));
+    return;
+  }
+  switch (r.kind) {
+    case 'ok':
+      stdout.writeln('✅ ${r.message}');
+      break;
+    case 'drift':
+      stderr.writeln('❌ README install pin is stale.');
+      stderr.writeln('   pubspec.yaml version : ${r.pubspec}');
+      stderr.writeln('   README.md  pin       : ${r.readme!.caret}');
+      stderr.writeln('');
+      stderr.writeln(
+        '   Bump README to `pixel_ui: ^${r.pubspec!.major}.${r.pubspec!.minor}.0` '
+        'or run:',
+      );
+      stderr.writeln('     dart run tool/check_readme_version.dart --fix');
+      break;
+    case 'fixed':
+      stdout.writeln(
+        '🔧 README pin updated: ${r.fromPin!.caret} → ${r.toPin!.caret} '
+        '(pubspec at ${r.pubspec}).',
+      );
+      break;
+    case 'error':
+      stderr.writeln('⚠️  ${r.message}');
+      break;
+  }
+}


### PR DESCRIPTION
Closes #50

## 변경사항

1. **README.md** — Install pin `^0.4.0` → `^0.5.0` (single-shot fix to match `pubspec.yaml` `version: 0.5.1`).
2. **`tool/check_readme_version.dart`** — new CI guard. Fails when README's `pixel_ui: ^X.Y` install pin falls behind pubspec's `version:` major.minor. Supports:
   - default → check, exit 1 on drift with actionable message
   - `--json` → machine-readable
   - `--fix` → auto-update README in place
3. **`.github/workflows/test.yml`** — wires `dart run tool/check_readme_version.dart` between `pub get` and `analyze` steps. Future PRs that bump `pubspec.yaml` version but forget the README pin will fail CI before merge.
4. **`CHANGELOG.md`** — `Unreleased` entry under `Docs` (README bump) and `Internal` (CI guard).

## 왜 자동화인가

- 단발 README bump 은 사이클 #1 의 #19 에서 한 번 (`^0.1.0 → ^0.2.0`), 이번 사이클 #3 의 #50 에서 두 번째 → release flow 에 보호 장치가 없어 매번 재발.
- `--fix` 모드로 로컬 self-heal 도 1초 컷. CI 가드 + `--fix` 조합이 humans-out-of-the-loop 으로는 가장 가벼움.
- publish.yml 자동 commit-back 은 token scope/ tag-after-commit 복잡성이 있어 미선택. CI 가드는 PR-time 에 막으니 근본적으로 더 안전.

## 검증

- [x] `fvm flutter analyze` — No issues found
- [x] `fvm flutter test --exclude-tags screenshot` — All 163 tests passed
- [x] `fvm dart run tool/check_readme_version.dart` — `✅ README pin ^0.5.0 covers pubspec 0.5.1.`
- [x] `--json` 모드 — `{"kind":"ok","message":"README pin ^0.5.0 covers pubspec 0.5.1.","readme_pin":"^0.5.0","pubspec_version":"0.5.1"}`
- [x] 합성 drift (`^0.4.0`) → `exit 1` + 안내 메시지
- [x] `--fix` 모드 — `^0.3.2 → ^0.5.0` 로 자동 패치 후 `exit 0`

## CI guard 동작 예시

drift 가 발생하면 PR 머지 차단. 출력:

```
❌ README install pin is stale.
   pubspec.yaml version : 0.5.1
   README.md  pin       : ^0.4.0

   Bump README to `pixel_ui: ^0.5.0` or run:
     dart run tool/check_readme_version.dart --fix
```

## 후속 작업 (별 PR)

- pre-commit hook 으로 `--fix` 자동 실행 → 옵션이지만 robustness 더 올림. 이번 PR 범위 밖.