### PR TITLE
docs: README sweep — Theming, PixelBox usage, Cookbook (closes #51 #52 #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Docs
 - README `## Install` version pin bumped `^0.4.0` → `^0.5.0` to match the current minor line (recurring drift; closes #50, follow-up to #19).
+- New `## Theming` section documenting `pixelUiTheme(...)` wire-up, the `PixelTheme` / `PixelBoxTheme` / `PixelButtonTheme` extensions, style resolution precedence, and the `context.pixelTheme<T>()` reader (closes #51). The theming system has been live since 0.3.0 but had zero presence in the README.
+- New `### PixelBox` subsection under `## Usage` with a standalone container example plus a `label:` / `labelLeftInset:` cutout walkthrough and a pointer to the `painter:` slot (closes #53). `PixelBox` was advertised as a primitive in Features but had no usage example in the README.
+- New `## Cookbook` section with three copy-pasteable recipes — HP / MP bar, NPC dialog frame with asymmetric corners + label, tappable inventory slot — so the pub.dev Example tab and first-time readers have short, self-contained patterns alongside the full `example/` showcase (closes #52).
 
 ### Internal
 - `tool/check_readme_version.dart` — CI guard that fails when `README.md`'s `pixel_ui: ^X.Y` install pin falls behind `pubspec.yaml`'s `version:` major.minor. Wired into `.github/workflows/test.yml` to prevent the recurring drift pattern at PR-time. Supports `--fix` for one-shot local repair and `--json` for tooling.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,119 @@ The logical values also drive corner stair patterns, shadow offsets, and
 texture cell sizes, so think of them as the "pixel art canvas" the design
 is authored on.
 
+## Theming
+
+Wire `pixelUiTheme(...)` once on `MaterialApp.theme` and any descendant
+`PixelBox` / `PixelButton` inherits its style — no need to repeat the same
+`style:` / `normalStyle:` on every call site.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:pixel_ui/pixel_ui.dart';
+
+final panelStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: const Color(0xFF333A4D),
+  borderColor: const Color(0xFF12141A),
+  borderWidth: 1,
+  shadow: PixelShadow.sm(const Color(0xFF000000)),
+);
+
+final buttonStyle = PixelShapeStyle(
+  corners: PixelCorners.md,
+  fillColor: const Color(0xFF5A8A3A),
+  borderColor: const Color(0xFF2A4820),
+  borderWidth: 1,
+);
+
+MaterialApp(
+  theme: pixelUiTheme(
+    base: ThemeData(brightness: Brightness.dark),
+    pixelTheme: PixelTheme(
+      box: PixelBoxTheme(style: panelStyle),
+      button: PixelButtonTheme(normalStyle: buttonStyle),
+    ),
+  ),
+  home: const SettingsScreen(),
+);
+
+// PixelBox / PixelButton may now omit their style props:
+PixelBox(logicalWidth: 80, logicalHeight: 60, child: ...);
+PixelButton(logicalWidth: 60, logicalHeight: 18, onPressed: () {}, child: ...);
+```
+
+`pixelUiTheme` accepts either a top-level `pixelTheme:` umbrella or
+individual `boxTheme:` / `buttonTheme:` slots — explicit slots win when both
+are provided.
+
+### Style resolution precedence
+
+For each widget, the first source that resolves a style is used:
+
+1. Explicit `style:` / `normalStyle:` (or `pressedStyle:` / `disabledStyle:`) prop on the widget call site
+2. The matching slot on `PixelBoxTheme` / `PixelButtonTheme` registered via `pixelUiTheme`
+3. Asserts in debug if neither source produces a style — `PixelButton` further falls back to `normalStyle` rendered at 50% opacity for the disabled state
+
+Read the resolved theme imperatively (e.g. inside a custom widget) with
+`context.pixelTheme<T>()`:
+
+```dart
+final boxTheme = context.pixelTheme<PixelBoxTheme>();
+final fill = boxTheme?.style?.fillColor ?? defaultFill;
+```
+
 ## Usage
+
+### PixelBox
+
+A pixel-styled container. Pass any widget as `child`; size by logical pixels
+(see [Sizing model](#sizing-model) above) or override with `width` / `height`.
+
+```dart
+PixelBox(
+  style: PixelShapeStyle(
+    corners: PixelCorners.md,
+    fillColor: const Color(0xFF333A4D),
+    borderColor: const Color(0xFF12141A),
+    borderWidth: 1,
+    shadow: PixelShadow.sm(const Color(0xFF000000)),
+  ),
+  logicalWidth: 80,
+  logicalHeight: 60,
+  padding: const EdgeInsets.all(8),
+  alignment: Alignment.topLeft,
+  child: Text('INVENTORY', style: PixelText.mulmaru(fontSize: 16)),
+);
+```
+
+`style:` is optional when [Theming](#theming) is wired up — the box resolves
+its style from `PixelBoxTheme.style` on the ancestor `Theme`.
+
+#### Top-border label cutout
+
+Pass a widget to `label:` and the painter carves a matching transparent
+cutout in the top border, so the label appears to sit *through* the frame —
+the classic `[ TITLE ]━━━━━` look. The cutout width is measured from the
+label widget at layout time; `labelLeftInset` (in **logical pixels**, default
+`2`) shifts it horizontally.
+
+```dart
+PixelBox(
+  style: panelStyle,
+  logicalWidth: 80,
+  logicalHeight: 60,
+  label: Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 4),
+    child: Text(' INVENTORY ', style: PixelText.mulmaru(fontSize: 12)),
+  ),
+  labelLeftInset: 4,
+  child: ...,
+);
+```
+
+To plug in a custom `CustomPainter` (procedural fills, animated patterns, …)
+without forking `PixelBox`, pass a `PixelShapePainterBuilder` to `painter:`
+(precedence: `painter` prop > `PixelBoxTheme.painter` > built-in default).
 
 ### Corners
 
@@ -260,6 +372,113 @@ Text(
   'HP 042/100',
   style: PixelText.mulmaruMono(fontSize: 12, color: Colors.white),
 )
+```
+
+## Cookbook
+
+Short, copy-pasteable recipes for common patterns. Each snippet stands alone
+— assume `import 'package:pixel_ui/pixel_ui.dart';` at the top.
+
+### HP / MP bar
+
+Layer a filled `PixelBox` over a track `PixelBox` and clip with a `SizedBox`
+proportional to the current value. Mono text reads "HP 042/100" without
+jitter as the digits change.
+
+```dart
+Widget hpBar({required int current, required int max, double width = 120}) {
+  final track = PixelShapeStyle(
+    corners: PixelCorners.sm,
+    fillColor: const Color(0xFF222732),
+    borderColor: const Color(0xFF000000),
+    borderWidth: 1,
+  );
+  final fill = PixelShapeStyle(
+    corners: PixelCorners.sm,
+    fillColor: const Color(0xFFD43A2F), // HP red
+  );
+
+  final ratio = (current / max).clamp(0.0, 1.0);
+  return Row(children: [
+    SizedBox(
+      width: width,
+      child: Stack(alignment: Alignment.centerLeft, children: [
+        PixelBox(style: track, logicalWidth: 60, logicalHeight: 4, width: width, height: 8),
+        SizedBox(
+          width: width * ratio,
+          child: PixelBox(style: fill, logicalWidth: 60, logicalHeight: 4, width: width * ratio, height: 8),
+        ),
+      ]),
+    ),
+    const SizedBox(width: 8),
+    Text(
+      'HP ${current.toString().padLeft(3, "0")}/$max',
+      style: PixelText.mulmaruMono(fontSize: 12, color: const Color(0xFFFFFFFF)),
+    ),
+  ]);
+}
+```
+
+### NPC dialog frame
+
+Use asymmetric corners (`PixelCorners.only`) for a top "tab" and `label:` to
+mount the speaker name through the border.
+
+```dart
+PixelBox(
+  style: PixelShapeStyle(
+    corners: const PixelCorners.only(tl: [3, 2, 1], tr: [3, 2, 1]),
+    fillColor: const Color(0xFF1B1F2A),
+    borderColor: const Color(0xFFFFD643),
+    borderWidth: 1,
+    shadow: PixelShadow.md(const Color(0xFF000000)),
+  ),
+  logicalWidth: 100,
+  logicalHeight: 40,
+  padding: const EdgeInsets.fromLTRB(12, 14, 12, 12),
+  alignment: Alignment.topLeft,
+  label: Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 4),
+    child: Text(
+      ' OLD MAN ',
+      style: PixelText.mulmaru(fontSize: 12, color: const Color(0xFFFFD643)),
+    ),
+  ),
+  labelLeftInset: 6,
+  child: Text(
+    '이 동굴 안엔\n무서운 게 산단다…',
+    style: PixelText.mulmaru(fontSize: 14, color: const Color(0xFFFFFFFF)),
+  ),
+);
+```
+
+### Tappable inventory slot
+
+Wrap a `PixelBox` background in a `PixelButton` for pressable feedback. For
+a full grid with keyboard focus and drag-and-drop, see
+[Tile grids](#tile-grids).
+
+```dart
+PixelButton(
+  logicalWidth: 16,
+  logicalHeight: 16,
+  normalStyle: PixelShapeStyle(
+    corners: PixelCorners.sm,
+    fillColor: const Color(0xFF333A4D),
+    borderColor: const Color(0xFF12141A),
+    borderWidth: 1,
+  ),
+  pressedStyle: PixelShapeStyle(
+    corners: PixelCorners.sm,
+    fillColor: const Color(0xFF5A8A3A),
+    borderColor: const Color(0xFF2A4820),
+    borderWidth: 1,
+  ),
+  pressChildOffset: const Offset(0, 1),
+  onPressed: () => useItem(),
+  semanticsLabel: 'Potion',
+  child: Text('🧪', style: PixelText.mulmaruMono(fontSize: 18)),
+);
 ```
 
 ## Gallery


### PR DESCRIPTION
Closes #51, #52, #53

## 변경사항

세 가지 docs 갭 모두 dogfood cycle #3 의 C2 페르소나(앱 UI 문서 독자) 가 같은 README 챕터에서 발견 → 한 PR 로 묶음.

### 1. `## Theming` (closes #51)

`Quick Start` ↔ `Usage` 사이에 새 섹션 신설.

- `pixelUiTheme(...)` wire-up 예제 (실제 API 시그니처 검증 후 작성: `PixelTheme(box:, button:)` — `boxTheme:`/`buttonTheme:` 아님)
- 3-단계 style resolution 우선순위 (widget prop > theme slot > assert)
- `context.pixelTheme<T>()` 리더 helper 사용 예
- 0.3.0 부터 살아있던 기능이지만 README 에는 그동안 zero mention

### 2. `### PixelBox` (closes #53)

`## Usage` 첫 서브섹션으로 추가.

- 단독 컨테이너 예제 (`style:`, `padding:`, `alignment:`, `child:` 모두 시연)
- `label:` + `labelLeftInset:` cutout 서브 예제 — \`[ TITLE ]━━━\` 룩
- `painter:` 슬롯 짧은 안내 (custom CustomPainter 주입 가능 사실)
- `style:` 가 theme 와 함께 optional 이라는 점 명시

### 3. `## Cookbook` (closes #52)

`## Usage` 와 `## Gallery` 사이 신설. 3개 패턴 — 각 < 30줄, self-contained:

- **HP / MP bar** — track + fill PixelBox 합성, mono 텍스트로 jitter 방지
- **NPC dialog frame** — asymmetric `PixelCorners.only(tl, tr)` + `label:` 합성
- **Tappable inventory slot** — PixelButton + `pressedStyle` + `pressChildOffset`

(설정 row / PixelListTile 패턴은 #49 머지 후 별 PR 로 추가 예정)

### 4. CHANGELOG `Unreleased` 엔트리

`## 0.5.1` 위에 누적 — 다음 release 시 자연스럽게 합쳐짐.

## 검증

- [x] `fvm dart run tool/check_readme_version.dart` — `✅ README pin ^0.5.0 covers pubspec 0.5.1.` (이번 PR 머지 후 #54 의 CI 가드도 자동 작동 확인됨)
- [x] `fvm flutter analyze` — No issues found
- [x] `fvm flutter test --exclude-tags screenshot` — All 163 tests passed
- [x] **README 코드 스니펫 compile-check** — 모든 snippet 을 임시 `example/lib/_readme_check.dart` 로 합쳐 `flutter analyze` 통과 확인. snippet 이 silently API 와 어긋나는 일 방지.

## 후속

- 이번 docs 사이클은 closes 3건. 남은 dogfood backlog: widget-gap #47 (PixelSwitch), #48 (PixelSlider), #49 (PixelListTile) — fast-track 진입.
- README 의 새 cookbook 패턴 1개라도 example/ 쇼케이스에 시각 데모로 추가하면 Gallery 섹션도 더 풍부해질 수 있음 (별 이슈로 분리 권장).